### PR TITLE
feat:新增添加卡券时自动生成发货规则选项

### DIFF
--- a/reply_server.py
+++ b/reply_server.py
@@ -5300,6 +5300,24 @@ def create_card(card_data: dict, current_user: Dict[str, Any] = Depends(get_curr
             user_id=user_id
         )
 
+        # 检查是否需要生成对应发货规则
+        generate_delivery_rule = card_data.get('generate_delivery_rule', False)
+        if generate_delivery_rule:
+            try:
+                # 生成发货规则
+                rule_id = db_manager.create_delivery_rule(
+                    keyword=card_data.get('name'),  # 商品关键字设置为卡券名称
+                    card_id=card_id,  # 匹配卡券设置为当前新添加的卡券ID
+                    delivery_count=1,  # 默认发货数量为1
+                    enabled=True,  # 默认启用
+                    description=f"自动生成的发货规则 - 对应卡券: {card_data.get('name')}",
+                    user_id=user_id
+                )
+                log_with_user('info', f"自动生成发货规则成功: 卡券ID={card_id}, 规则ID={rule_id}", current_user)
+            except Exception as e:
+                log_with_user('error', f"生成发货规则失败: {str(e)}", current_user)
+                # 不影响卡券创建，仅记录错误
+
         log_with_user('info', f"卡券创建成功: {card_name} (ID: {card_id})", current_user)
         return {"id": card_id, "message": "卡券创建成功"}
     except Exception as e:

--- a/static/index.html
+++ b/static/index.html
@@ -3305,6 +3305,19 @@
               </small>
             </div>
 
+            <div class="mb-3">
+              <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" id="generateDeliveryRule">
+                <label class="form-check-label" for="generateDeliveryRule">
+                  <strong>生成对应发货规则</strong>
+                </label>
+              </div>
+              <small class="form-text text-muted">
+                <i class="bi bi-info-circle me-1"></i>
+                启用后，创建卡券时会自动生成一条对应的自动发货规则，商品关键字为当前卡券名称，匹配卡券为当前卡券。
+              </small>
+            </div>
+
             <!-- 多规格设置 -->
             <div class="mb-3">
               <div class="form-check form-switch">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -5838,13 +5838,19 @@ async function saveCard() {
         break;
     }
 
+    // 获取"生成对应发货规则"开关状态
+    const generateDeliveryRule = document.getElementById('generateDeliveryRule').checked;
+    
     const response = await fetch(`${apiBase}/cards`, {
         method: 'POST',
         headers: {
         'Authorization': `Bearer ${authToken}`,
         'Content-Type': 'application/json'
         },
-        body: JSON.stringify(cardData)
+        body: JSON.stringify({
+            ...cardData,
+            generate_delivery_rule: generateDeliveryRule
+        })
     });
 
     if (response.ok) {


### PR DESCRIPTION
### 背景
在实际使用时，存在商品关键字用作卡券名称的情况，因此可以在添加卡券的同时创建发货规则，简化操作流程。

### 功能描述
在添加卡券的对话框中新增"生成对应发货规则"开关选项，默认关闭，启用后在创建卡券的同时自动创建一条关联的发货规则。

### 功能变更 
1. 前端界面 ( static/index.html )
- 在添加卡券模态框底部新增"生成对应发货规则"开关控件
- 添加相关说明文字，提示用户该功能的作用 
2. 前端逻辑 ( static/js/app.js )
- 修改 saveCard 函数，在保存卡券时获取开关状态
- 将 generate_delivery_rule 参数随卡券数据一起发送至后端 API 
3. 后端 API ( reply_server.py )
- 修改 create_card 函数，新增对 generate_delivery_rule 参数的处理
- 当参数为 true 时，自动调用 db_manager.create_delivery_rule() 创建发货规则
- 发货规则配置：
  - 商品关键字：卡券名称
  - 匹配卡券 ：关联当前新创建的卡券
  - 发货数量 ：默认为 1
  - 启用状态 ：默认启用
  - 规则描述 ：自动生成，包含对应卡券名称

### 相关文件
- static/index.html - 添加开关 UI
- static/js/app.js - 前端逻辑处理
- reply_server.py - 后端 API 实现