### PR TITLE
fix: 自动发货失败的问题

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -16,7 +16,6 @@ from loguru import logger
 
 def get_local_timestamp() -> str:
     """获取本地时间字符串，用于替换SQLite的CURRENT_TIMESTAMP（UTC时间）"""
-    logger.info(f"本地时间: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
     return datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 
 class DBManager:


### PR DESCRIPTION
## 🐛 问题描述
[简化消息]场景下，需通过查询[10分钟内的]数据库订单实现，
而在插入及更新订单记录时，时间相关字段使用了CURRENT_TIMESTAMP，默认为UTC(+0)，和北京时间相差8小时，导致订单查询失败，进而影响自动发货。

## 🛠️ 解决方案
使用本地时间作为create_at和update_at字段的值。

## ❗ 其他
1. 另有几十张表的创建、插入、查询、更新，均存在这个问题，需要择期统一修改。
2. 处理[简化消息]时，需要启动浏览器查询订单数据，整个过程需要近10秒的时间，另外设置了[延迟30秒后处理简化发货]，在即时发货的场景表现不佳。可以考虑用其他方式实现。