### PR TITLE
fix: 修复订单详情规格解析失败导致自动发货被阻断

### DIFF
--- a/utils/order_detail_fetcher.py
+++ b/utils/order_detail_fetcher.py
@@ -738,6 +738,107 @@ class OrderDetailFetcher:
             return None
         return normalized
 
+    def _normalize_sku_candidate_text(self, sku_text: Any) -> str:
+        if sku_text is None:
+            return ''
+        return re.sub(r'\s+', ' ', str(sku_text).replace('：', ':')).strip()
+
+    def _is_numeric_index_spec_name_like(self, spec_name: str, spec_value: str) -> bool:
+        normalized_name = re.sub(r'\s+', '', (spec_name or '').strip())
+        normalized_value = re.sub(r'\s+', ' ', (spec_value or '').strip())
+        if not normalized_name or not normalized_value:
+            return False
+
+        if not re.fullmatch(r'(?:第)?\d{1,2}(?:项|号|档)?', normalized_name):
+            return False
+
+        if len(normalized_value) < 2 or len(normalized_value) > 40:
+            return False
+
+        if self._is_datetime_like(normalized_value):
+            return False
+
+        if re.fullmatch(r'[¥￥]?\d+(?:\.\d{1,2})?', normalized_value):
+            return False
+
+        if normalized_value.lower().startswith(('http://', 'https://', 'fleamarket://')):
+            return False
+
+        if not re.search(r'[\u4e00-\u9fffA-Za-z]', normalized_value):
+            return False
+
+        return True
+
+    def _score_sku_text_candidate(
+        self,
+        normalized_key: str,
+        *,
+        path: str = '',
+        context: str = '',
+        sku_text: str = '',
+        from_pair: bool = False
+    ) -> int:
+        key = str(normalized_key or '').lower()
+        path_lower = str(path or '').lower()
+        normalized_context = re.sub(r'\s+', ' ', str(context or '')).strip()
+        normalized_sku_text = self._normalize_sku_candidate_text(sku_text)
+
+        if not normalized_sku_text or len(normalized_sku_text) > 120 or ':' not in normalized_sku_text:
+            return 0
+
+        score = 0
+        strong_keys = {
+            'skuinfo', 'sku_info', 'skutext', 'sku_text', 'skudesc', 'sku_desc',
+            'skucontent', 'sku_content', 'specinfo', 'spec_info', 'spectext',
+            'spec_text', 'specdesc', 'spec_desc', 'itemsku', 'item_sku',
+            'itemspec', 'item_spec'
+        }
+        medium_key_tokens = ('sku', 'spec', 'attr', 'property', 'option', 'variant', 'model')
+
+        if key in strong_keys:
+            score = 220
+        elif any(token in key for token in medium_key_tokens):
+            score = 170
+        elif from_pair:
+            score = 135
+        elif any(token in path_lower for token in ('.sku', '.spec', '.attr', '.property', '.option', '.variant', '.model')):
+            score = 120
+        else:
+            return 0
+
+        if '.iteminfo.' in path_lower:
+            score += 70
+        elif '.components[' in path_lower:
+            score += 20
+
+        if any(token in normalized_context for token in ('规格', '型号', '版本', '选项', '属性', '套餐')):
+            score += 35
+
+        if ';' in normalized_sku_text:
+            score += 10
+
+        return score
+
+    def _append_sku_candidate(
+        self,
+        candidates: List[Dict[str, Any]],
+        sku_text: Any,
+        *,
+        quantity: Optional[str] = None,
+        path: str = '',
+        score: int = 0
+    ) -> None:
+        normalized_sku_text = self._normalize_sku_candidate_text(sku_text)
+        if score <= 0 or not normalized_sku_text or len(normalized_sku_text) > 120 or ':' not in normalized_sku_text:
+            return
+
+        candidates.append({
+            'sku_text': normalized_sku_text,
+            'quantity': quantity,
+            'path': path,
+            'score': score,
+        })
+
     def _extract_sku_candidates_from_payload(self, payload: Any, path: str = 'root', depth: int = 0) -> List[Dict[str, Any]]:
         if payload is None or depth > 8:
             return []
@@ -752,28 +853,94 @@ class OrderDetailFetcher:
                     if quantity_context:
                         break
 
+            context_fields = []
+            for context_key in ('title', 'label', 'name', 'preText', 'subTitle', 'displayText', 'content', 'desc', 'text'):
+                context_value = payload.get(context_key)
+                if isinstance(context_value, (str, int, float)):
+                    normalized_context_value = self._normalize_sku_candidate_text(context_value)
+                    if normalized_context_value:
+                        context_fields.append(normalized_context_value)
+            dict_context = ' | '.join(context_fields)[:240]
+
+            title_text = ''
+            title_key = ''
+            for candidate_key in ('title', 'label', 'name', 'preText', 'subTitle', 'displayText', 'key', 'attrName', 'specName', 'skuName'):
+                candidate_value = payload.get(candidate_key)
+                if isinstance(candidate_value, (str, int, float)):
+                    normalized_title = self._normalize_sku_candidate_text(candidate_value)
+                    if normalized_title:
+                        title_text = normalized_title
+                        title_key = candidate_key
+                        break
+
+            value_text = ''
+            value_key = ''
+            for candidate_key in ('value', 'text', 'content', 'displayText', 'attrValue', 'specValue', 'skuValue'):
+                candidate_value = payload.get(candidate_key)
+                if isinstance(candidate_value, (str, int, float)):
+                    normalized_value = self._normalize_sku_candidate_text(candidate_value)
+                    if normalized_value:
+                        value_text = normalized_value
+                        value_key = candidate_key
+                        break
+
+            if not quantity_context and title_text and value_text and any(token in title_text for token in ('数量', '购买数量', '件数')):
+                quantity_context = self._normalize_quantity_text(value_text)
+
+            if (
+                title_text and value_text and
+                ':' not in title_text and ':' not in value_text and
+                (
+                    self._is_text_fallback_spec_name_like(title_text) or
+                    self._is_numeric_index_spec_name_like(title_text, value_text)
+                )
+            ):
+                pair_path = f"{path}.{title_key}+{value_key}" if title_key and value_key else path
+                pair_sku_text = f"{title_text}:{value_text}"
+                pair_score = self._score_sku_text_candidate(
+                    f"{title_key}_{value_key}",
+                    path=pair_path,
+                    context=dict_context,
+                    sku_text=pair_sku_text,
+                    from_pair=True
+                )
+                self._append_sku_candidate(
+                    candidates,
+                    pair_sku_text,
+                    quantity=quantity_context,
+                    path=pair_path,
+                    score=pair_score
+                )
+
             for key, value in payload.items():
                 key_text = str(key)
-                normalized_key = key_text.lower()
+                normalized_key = re.sub(r'[^0-9A-Za-z\u4e00-\u9fff]', '', key_text).lower()
                 key_path = f"{path}.{key_text}"
 
-                if normalized_key in {'skuinfo', 'sku_info', 'skutext', 'sku_text', 'skudesc', 'sku_desc'} and isinstance(value, str):
-                    sku_text = re.sub(r'\s+', ' ', value).strip()
-                    if sku_text and len(sku_text) <= 120 and (':' in sku_text or '：' in sku_text):
-                        score = 180
-                        if '.itemInfo.' in key_path:
-                            score += 80
-                        if quantity_context:
-                            score += 10
-                        if ';' in sku_text:
-                            score += 10
+                if isinstance(value, str):
+                    nested_payload = self._try_parse_json_text(value)
+                    if nested_payload is not None:
+                        candidates.extend(
+                            self._extract_sku_candidates_from_payload(
+                                nested_payload,
+                                path=f"{key_path}.json",
+                                depth=depth + 1
+                            )
+                        )
 
-                        candidates.append({
-                            'sku_text': sku_text,
-                            'quantity': quantity_context,
-                            'path': key_path,
-                            'score': score,
-                        })
+                    score = self._score_sku_text_candidate(
+                        normalized_key,
+                        path=key_path,
+                        context=dict_context,
+                        sku_text=value
+                    )
+                    self._append_sku_candidate(
+                        candidates,
+                        value,
+                        quantity=quantity_context,
+                        path=key_path,
+                        score=score
+                    )
 
                 candidates.extend(self._extract_sku_candidates_from_payload(value, path=key_path, depth=depth + 1))
 
@@ -1106,6 +1273,27 @@ class OrderDetailFetcher:
         )
         return ranked_candidates[0] if ranked_candidates else None
 
+    def _get_ranked_captured_sku_candidates(self) -> List[Dict[str, Any]]:
+        if not self._captured_sku_candidates:
+            return []
+
+        deduped: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
+        for candidate in self._captured_sku_candidates:
+            dedupe_key = (
+                str(candidate.get('sku_text', '')),
+                str(candidate.get('quantity', '')),
+                str(candidate.get('path', '')),
+            )
+            existing = deduped.get(dedupe_key)
+            if existing is None or candidate.get('score', 0) > existing.get('score', 0):
+                deduped[dedupe_key] = candidate
+
+        return sorted(
+            deduped.values(),
+            key=lambda item: (item.get('score', 0), len(str(item.get('sku_text', '')))),
+            reverse=True,
+        )
+
     async def _extract_amount_from_structured_content(self) -> Tuple[Optional[str], str]:
         await self._wait_for_response_capture_tasks(timeout=1.5)
 
@@ -1167,30 +1355,30 @@ class OrderDetailFetcher:
     async def _extract_sku_from_structured_content(self) -> Dict[str, str]:
         await self._wait_for_response_capture_tasks(timeout=1.5)
 
-        best_candidate = self._get_best_captured_sku_candidate()
-        if not best_candidate:
-            return {}
+        for candidate in self._get_ranked_captured_sku_candidates():
+            sku_text = str(candidate.get('sku_text') or '').strip()
+            if not sku_text:
+                continue
 
-        sku_text = str(best_candidate.get('sku_text') or '').strip()
-        if not sku_text:
-            return {}
+            parsed = self._parse_sku_content(sku_text)
+            if not parsed:
+                continue
 
-        parsed = self._parse_sku_content(sku_text)
-        if not parsed:
-            return {}
+            sanitized = self._sanitize_sku_result(parsed, source='structured_response_candidate')
+            if not (sanitized.get('spec_name') and sanitized.get('spec_value')):
+                continue
 
-        sanitized = self._sanitize_sku_result(parsed, source='structured_response_candidate')
-        quantity = self._normalize_quantity_text(best_candidate.get('quantity'))
-        if quantity:
-            sanitized['quantity'] = quantity
+            quantity = self._normalize_quantity_text(candidate.get('quantity'))
+            if quantity:
+                sanitized['quantity'] = quantity
 
-        if sanitized:
             logger.info(
                 f"采用结构化响应规格候选: sku={sku_text}, quantity={quantity or ''}, "
-                f"path={best_candidate.get('path')}"
+                f"path={candidate.get('path')}"
             )
+            return sanitized
 
-        return sanitized
+        return {}
 
     async def _extract_amount_from_semantic_blocks(self) -> Tuple[Optional[str], str]:
         semantic_keywords = [
@@ -1492,6 +1680,10 @@ class OrderDetailFetcher:
             r'^发货方式$',
             r'^安装方式$',
             r'^接口$',
+            r'^地区$',
+            r'^区域$',
+            r'^省份$',
+            r'^城市$',
             r'^选项\d*$',
             r'^属性\d*$',
             r'^服务器$',
@@ -1539,7 +1731,10 @@ class OrderDetailFetcher:
         if any(token in lower_value for token in invalid_tokens):
             return False
 
-        if strict and not self._is_text_fallback_spec_name_like(name):
+        if strict and not (
+            self._is_text_fallback_spec_name_like(name) or
+            self._is_numeric_index_spec_name_like(name, value)
+        ):
             return False
 
         return True


### PR DESCRIPTION
## 问题

自动发货链路本身是通的，已经可以正常：

- 提取 `order_id`
- 拉取订单详情
- 写入订单库

但规格商品在自动发货时，经常出现订单详情已获取成功，`order_status` 和 `amount` 都正常，`spec_name/spec_value` 为空，最终被保护逻辑拦截，导致自动发货不生效。

## 原因

订单详情规格解析存在三个问题：

1. 旧的页面规格选择器命中率低，当前订单页经常拿不到规格节点
2. 结构化响应里的规格提取范围过窄，只识别少量固定键名，无法覆盖当前常见的 `title/value`、`label/value` 和字符串化 JSON 结构
3. 文本兜底对 `1:xxx` 这类数字占位规格名过滤过严，导致实际有效规格被误判为无效

## 修改

本 PR 仅修改：

- `utils/order_detail_fetcher.py`

核心改动：

- 新增规格候选归一化、评分和收集逻辑
- 支持从 `title/value`、`label/value`、嵌套 JSON 字符串以及更多 `sku/spec/attr/property/option` 相关字段中提取规格候选
- 结构化规格解析从“只取最高分单候选”改为“按候选排序依次尝试”，避免坏候选挡住真实规格
- 放宽受控场景下的数字型规格名校验，允许保留类似 `1:dy代发视频` 的有效规格
- 保留原有时间、订单号、付款信息、地址等误命中过滤，避免错发

## 效果

修复后，规格商品不再因为“订单详情已获取但规格为空”被误判为无规格订单。

自动发货保护逻辑本身没有放开，只是把原本已经存在于订单详情里的规格正确解析出来，使后续规则匹配和自动发货可以继续执行。

## 验证

修复前，真实订单可以稳定复现：

- 订单状态可解析为 `pending_ship`
- 金额可解析为 `0.01`
- 订单可成功写库
- 但 `spec_name/spec_value` 为空，自动发货被阻断

修复后，真实触发场景下自动发货已恢复正常。
