### PR TITLE
feat: 重构在线客服模块 — 自建聊天UI替代跨域iframe

### DIFF
--- a/XianyuAutoAsync.py
+++ b/XianyuAutoAsync.py
@@ -11243,6 +11243,29 @@ class XianyuLive:
 
         return []
 
+    def _extract_image_url_from_message(self, message: dict) -> Optional[str]:
+        """从消息结构中提取图片URL"""
+        try:
+            message_1 = message.get('1', {})
+            if not isinstance(message_1, dict):
+                return None
+            message_6 = message_1.get('6', {})
+            if not isinstance(message_6, dict):
+                return None
+            message_6_3 = message_6.get('3', {})
+            if not isinstance(message_6_3, dict):
+                return None
+            content_json_str = message_6_3.get('5', '')
+            if content_json_str:
+                import json as _json
+                content_obj = _json.loads(content_json_str)
+                pics = content_obj.get('image', {}).get('pics', [])
+                if pics:
+                    return pics[0].get('url', '')
+        except Exception:
+            pass
+        return None
+
     async def send_heartbeat(self, ws):
         """发送心跳包"""
         # 检查WebSocket连接状态，如果已关闭则不发送
@@ -13445,6 +13468,24 @@ class XianyuLive:
                     # 记录发出的消息
                     msg_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
                     logger.info(f"[{msg_time}] 【{reply_source}发出】用户: {send_user_name} (ID: {send_user_id}), 商品({item_id}): {reply}")
+                    # 保存发出的消息到数据库并推送SSE事件
+                    try:
+                        from db_manager import db_manager as _db
+                        from chat_event_hub import publish_chat_message
+                        _msg_id_db = _db.save_chat_message(
+                            cookie_id=self.cookie_id, chat_id=chat_id,
+                            sender_id=self.myid, sender_name=self.cookie_id,
+                            content=reply, content_type=1,
+                            item_id=item_id, direction=1, reply_source=reply_source
+                        )
+                        publish_chat_message(self.cookie_id, {
+                            "msg_id": _msg_id_db, "chat_id": chat_id,
+                            "sender_id": self.myid, "sender_name": self.cookie_id,
+                            "content": reply, "content_type": 1,
+                            "item_id": item_id, "direction": 1, "reply_source": reply_source,
+                        })
+                    except Exception as _e:
+                        logger.debug(f"保存/推送发出消息失败: {self._safe_str(_e)}")
             else:
                 msg_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
                 logger.info(f"[{msg_time}] 【{self.cookie_id}】【系统】未找到匹配的回复规则，不回复")
@@ -13927,6 +13968,26 @@ class XianyuLive:
 
             if send_user_id == self.myid and not is_system_message:
                 logger.info(f"[{msg_time}] 【{self.cookie_id}】[{msg_id}] 【手动发出】 商品({item_id}): {send_message}")
+                # 保存手动发出的消息到数据库并推送SSE事件
+                try:
+                    from db_manager import db_manager as _db
+                    from chat_event_hub import publish_chat_message
+                    _msg_id_db = _db.save_chat_message(
+                        cookie_id=self.cookie_id, chat_id=chat_id,
+                        sender_id=self.myid, sender_name=self.cookie_id,
+                        content=send_message, content_type=content_type,
+                        image_url=self._extract_image_url_from_message(message) if content_type == 2 else None,
+                        item_id=item_id, direction=1, reply_source='手动'
+                    )
+                    publish_chat_message(self.cookie_id, {
+                        "msg_id": _msg_id_db, "chat_id": chat_id,
+                        "sender_id": self.myid, "sender_name": self.cookie_id,
+                        "content": send_message, "content_type": content_type,
+                        "image_url": self._extract_image_url_from_message(message) if content_type == 2 else None,
+                        "item_id": item_id, "direction": 1, "reply_source": "手动",
+                    })
+                except Exception as _e:
+                    logger.debug(f"保存/推送手动消息失败: {self._safe_str(_e)}")
 
                 # 暂停该chat_id的自动回复10分钟
                 pause_manager.pause_chat(chat_id, self.cookie_id)
@@ -13940,6 +14001,26 @@ class XianyuLive:
                 )
             else:
                 logger.info(f"[{msg_time}] 【收到】用户: {send_user_name} (ID: {send_user_id}), 商品({item_id}): {send_message}")
+                # 保存收到的消息到数据库并推送SSE事件
+                try:
+                    from db_manager import db_manager as _db
+                    from chat_event_hub import publish_chat_message
+                    _msg_id_db = _db.save_chat_message(
+                        cookie_id=self.cookie_id, chat_id=chat_id,
+                        sender_id=send_user_id, sender_name=send_user_name,
+                        content=send_message, content_type=content_type,
+                        image_url=self._extract_image_url_from_message(message) if content_type == 2 else None,
+                        item_id=item_id, direction=2
+                    )
+                    publish_chat_message(self.cookie_id, {
+                        "msg_id": _msg_id_db, "chat_id": chat_id,
+                        "sender_id": send_user_id, "sender_name": send_user_name,
+                        "content": send_message, "content_type": content_type,
+                        "image_url": self._extract_image_url_from_message(message) if content_type == 2 else None,
+                        "item_id": item_id, "direction": 2,
+                    })
+                except Exception as _e:
+                    logger.debug(f"保存/推送聊天消息失败: {self._safe_str(_e)}")
                 if message_route == 'user_chat':
                     self.last_user_chat_time = time.time()
 

--- a/chat_event_hub.py
+++ b/chat_event_hub.py
@@ -1,0 +1,69 @@
+import queue
+import threading
+import time
+from collections import defaultdict
+from typing import Any, Dict, Optional
+
+from loguru import logger
+
+
+class ChatEventHub:
+    """进程内聊天事件中心，按 user_id 广播聊天消息。"""
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._subscribers = defaultdict(set)
+
+    def subscribe(self, user_id: int, maxsize: int = 200):
+        subscriber = queue.Queue(maxsize=maxsize)
+        with self._lock:
+            self._subscribers[user_id].add(subscriber)
+        return subscriber
+
+    def unsubscribe(self, user_id: int, subscriber):
+        with self._lock:
+            subscribers = self._subscribers.get(user_id)
+            if not subscribers:
+                return
+            subscribers.discard(subscriber)
+            if not subscribers:
+                self._subscribers.pop(user_id, None)
+
+    def publish(self, user_id: int, event: Dict[str, Any]):
+        with self._lock:
+            subscribers = list(self._subscribers.get(user_id, set()))
+
+        for subscriber in subscribers:
+            try:
+                subscriber.put_nowait(event)
+            except queue.Full:
+                try:
+                    subscriber.get_nowait()
+                except queue.Empty:
+                    pass
+                try:
+                    subscriber.put_nowait(event)
+                except queue.Full:
+                    logger.warning(f"聊天事件队列仍然已满，丢弃事件: user_id={user_id}")
+
+
+chat_event_hub = ChatEventHub()
+
+
+def publish_chat_message(cookie_id: str, message_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """发布聊天消息事件到对应的系统用户。"""
+    from db_manager import db_manager
+
+    cookie_info = db_manager.get_cookie_details(cookie_id)
+    user_id = cookie_info.get('user_id') if cookie_info else None
+    if user_id is None:
+        return None
+
+    event = {
+        "type": "chat.message",
+        "timestamp": int(time.time() * 1000),
+        "cookie_id": cookie_id,
+        "data": message_data,
+    }
+    chat_event_hub.publish(user_id, event)
+    return event

--- a/db_manager.py
+++ b/db_manager.py
@@ -826,6 +826,26 @@ class DBManager:
             )
             ''')
 
+            # 创建聊天消息表
+            cursor.execute('''
+            CREATE TABLE IF NOT EXISTS chat_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                cookie_id TEXT NOT NULL,
+                chat_id TEXT NOT NULL,
+                sender_id TEXT NOT NULL,
+                sender_name TEXT DEFAULT '',
+                content TEXT NOT NULL DEFAULT '',
+                content_type INTEGER DEFAULT 1,
+                image_url TEXT,
+                item_id TEXT,
+                direction INTEGER DEFAULT 2,
+                reply_source TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (cookie_id) REFERENCES cookies(id) ON DELETE CASCADE
+            )
+            ''')
+            cursor.execute('CREATE INDEX IF NOT EXISTS idx_chat_messages_lookup ON chat_messages(cookie_id, chat_id, created_at)')
+
             # 插入默认通知模板
             cursor.execute('''
             INSERT OR IGNORE INTO notification_templates (type, template) VALUES
@@ -9003,6 +9023,225 @@ Cookie数量: {cookie_count}
                 logger.error(f"更新任务执行结果失败: {e}")
                 self.conn.rollback()
                 return False
+
+    # ==================== 聊天消息 ====================
+
+    def save_chat_message(self, cookie_id: str, chat_id: str, sender_id: str,
+                          sender_name: str, content: str, content_type: int = 1,
+                          image_url: str = None, item_id: str = None,
+                          direction: int = 2, reply_source: str = None,
+                          created_at: str = None) -> Optional[int]:
+        """保存聊天消息"""
+        try:
+            cursor = self.conn.cursor()
+            if created_at:
+                self._execute_sql(cursor, """
+                    INSERT INTO chat_messages (cookie_id, chat_id, sender_id, sender_name,
+                        content, content_type, image_url, item_id, direction, reply_source, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, (cookie_id, chat_id, sender_id, sender_name, content,
+                      content_type, image_url, item_id, direction, reply_source, created_at))
+            else:
+                self._execute_sql(cursor, """
+                    INSERT INTO chat_messages (cookie_id, chat_id, sender_id, sender_name,
+                        content, content_type, image_url, item_id, direction, reply_source)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, (cookie_id, chat_id, sender_id, sender_name, content,
+                      content_type, image_url, item_id, direction, reply_source))
+            self.conn.commit()
+            return cursor.lastrowid
+        except Exception as e:
+            logger.error(f"保存聊天消息失败: {e}")
+            self.conn.rollback()
+            return None
+
+    def get_chat_sessions(self, cookie_id: str, limit: int = 50) -> list:
+        """获取指定账号的会话列表（按最新消息排序），包含买家名称"""
+        try:
+            cursor = self.conn.cursor()
+            self._execute_sql(cursor, """
+                SELECT m.chat_id, m.sender_name, m.content, m.content_type,
+                       m.item_id, m.created_at, m.direction, m.sender_id,
+                       buyer.buyer_name, buyer.buyer_id
+                FROM chat_messages m
+                INNER JOIN (
+                    SELECT chat_id, MAX(id) AS max_id
+                    FROM chat_messages
+                    WHERE cookie_id = ?
+                    GROUP BY chat_id
+                ) latest ON m.chat_id = latest.chat_id AND m.id = latest.max_id
+                LEFT JOIN (
+                    SELECT chat_id, sender_name AS buyer_name, sender_id AS buyer_id
+                    FROM chat_messages
+                    WHERE cookie_id = ? AND direction = 2 AND sender_name != ''
+                    GROUP BY chat_id
+                ) buyer ON m.chat_id = buyer.chat_id
+                WHERE m.cookie_id = ?
+                ORDER BY m.created_at DESC
+                LIMIT ?
+            """, (cookie_id, cookie_id, cookie_id, limit))
+            rows = cursor.fetchall()
+            columns = [desc[0] for desc in cursor.description]
+            return [dict(zip(columns, row)) for row in rows]
+        except Exception as e:
+            logger.error(f"获取会话列表失败: {e}")
+            return []
+
+    def get_chat_messages(self, cookie_id: str, chat_id: str, limit: int = 50, before_id: int = None) -> list:
+        """获取指定会话的消息列表"""
+        try:
+            cursor = self.conn.cursor()
+            if before_id:
+                self._execute_sql(cursor, """
+                    SELECT id, cookie_id, chat_id, sender_id, sender_name, content,
+                           content_type, image_url, item_id, direction, reply_source, created_at
+                    FROM chat_messages
+                    WHERE cookie_id = ? AND chat_id = ? AND id < ?
+                    ORDER BY id DESC
+                    LIMIT ?
+                """, (cookie_id, chat_id, before_id, limit))
+            else:
+                self._execute_sql(cursor, """
+                    SELECT id, cookie_id, chat_id, sender_id, sender_name, content,
+                           content_type, image_url, item_id, direction, reply_source, created_at
+                    FROM chat_messages
+                    WHERE cookie_id = ? AND chat_id = ?
+                    ORDER BY id DESC
+                    LIMIT ?
+                """, (cookie_id, chat_id, limit))
+            rows = cursor.fetchall()
+            columns = [desc[0] for desc in cursor.description]
+            result = [dict(zip(columns, row)) for row in rows]
+            result.reverse()
+            return result
+        except Exception as e:
+            logger.error(f"获取聊天消息失败: {e}")
+            return []
+
+    def cleanup_old_chat_messages(self, days: int = 30) -> int:
+        """清理指定天数前的聊天消息"""
+        try:
+            cursor = self.conn.cursor()
+            self._execute_sql(cursor, """
+                DELETE FROM chat_messages
+                WHERE created_at < datetime('now', ?)
+            """, (f'-{days} days',))
+            deleted = cursor.rowcount
+            self.conn.commit()
+            if deleted > 0:
+                logger.info(f"清理了 {deleted} 条过期聊天消息（{days}天前）")
+            return deleted
+        except Exception as e:
+            logger.error(f"清理聊天消息失败: {e}")
+            self.conn.rollback()
+            return 0
+
+    # ==================== 商品关键词（按 item_id） ====================
+
+    def get_keywords_by_item_id(self, cookie_id: str, item_id: str) -> list:
+        """获取指定商品的关键词列表"""
+        try:
+            cursor = self.conn.cursor()
+            if item_id:
+                self._execute_sql(cursor, """
+                    SELECT k.keyword, k.reply, k.item_id, k.type, k.image_url,
+                           i.item_title
+                    FROM keywords k
+                    LEFT JOIN item_info i ON k.item_id = i.item_id AND k.cookie_id = i.cookie_id
+                    WHERE k.cookie_id = ? AND k.item_id = ?
+                    ORDER BY k.rowid
+                """, (cookie_id, item_id))
+            else:
+                self._execute_sql(cursor, """
+                    SELECT k.keyword, k.reply, k.item_id, k.type, k.image_url,
+                           NULL as item_title
+                    FROM keywords k
+                    WHERE k.cookie_id = ? AND (k.item_id IS NULL OR k.item_id = '')
+                    ORDER BY k.rowid
+                """, (cookie_id,))
+            rows = cursor.fetchall()
+            columns = [desc[0] for desc in cursor.description]
+            return [dict(zip(columns, row)) for row in rows]
+        except Exception as e:
+            logger.error(f"获取商品关键词失败: {e}")
+            return []
+
+    def save_keywords_for_item(self, cookie_id: str, item_id: str,
+                               keywords: list) -> bool:
+        """保存指定商品的关键词（仅影响该 item_id 的记录）
+        keywords: [{"keyword": str, "reply": str, "type": "text"|"image", "image_url": str|None}]
+        """
+        try:
+            cursor = self.conn.cursor()
+            # 删除该商品下所有旧关键词
+            if item_id:
+                self._execute_sql(cursor,
+                    "DELETE FROM keywords WHERE cookie_id = ? AND item_id = ?",
+                    (cookie_id, item_id))
+            else:
+                self._execute_sql(cursor,
+                    "DELETE FROM keywords WHERE cookie_id = ? AND (item_id IS NULL OR item_id = '')",
+                    (cookie_id,))
+            # 插入新关键词
+            for kw in keywords:
+                kw_type = kw.get('type', 'text')
+                self._execute_sql(cursor, """
+                    INSERT INTO keywords (cookie_id, keyword, reply, item_id, type, image_url)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                """, (cookie_id, kw['keyword'], kw.get('reply', ''),
+                      item_id or None, kw_type, kw.get('image_url')))
+            self.conn.commit()
+            return True
+        except Exception as e:
+            logger.error(f"保存商品关键词失败: {e}")
+            self.conn.rollback()
+            return False
+
+    def copy_keywords_to_item(self, cookie_id: str, source_item_id: str,
+                              target_item_id: str) -> int:
+        """将源商品的关键词复制到目标商品（覆盖目标商品已有关键词）"""
+        try:
+            source_kws = self.get_keywords_by_item_id(cookie_id, source_item_id)
+            if not source_kws:
+                return 0
+            # 转换格式
+            kw_list = [{
+                'keyword': kw['keyword'],
+                'reply': kw.get('reply', ''),
+                'type': kw.get('type', 'text'),
+                'image_url': kw.get('image_url'),
+            } for kw in source_kws]
+            self.save_keywords_for_item(cookie_id, target_item_id, kw_list)
+            return len(kw_list)
+        except Exception as e:
+            logger.error(f"复制关键词失败: {e}")
+            return 0
+
+    def get_all_chat_sessions(self, user_id: int, limit: int = 200) -> list:
+        """获取用户所有账号的会话列表（三栏布局用）"""
+        try:
+            cursor = self.conn.cursor()
+            self._execute_sql(cursor, """
+                SELECT m.cookie_id, m.chat_id, m.sender_name, m.content,
+                       m.content_type, m.item_id, m.created_at, m.direction, m.sender_id
+                FROM chat_messages m
+                INNER JOIN (
+                    SELECT cookie_id, chat_id, MAX(id) AS max_id
+                    FROM chat_messages
+                    WHERE cookie_id IN (SELECT id FROM cookies WHERE user_id = ?)
+                    GROUP BY cookie_id, chat_id
+                ) latest ON m.cookie_id = latest.cookie_id
+                           AND m.chat_id = latest.chat_id
+                           AND m.id = latest.max_id
+                ORDER BY m.created_at DESC
+                LIMIT ?
+            """, (user_id, limit))
+            rows = cursor.fetchall()
+            columns = [desc[0] for desc in cursor.description]
+            return [dict(zip(columns, row)) for row in rows]
+        except Exception as e:
+            logger.error(f"获取全量会话列表失败: {e}")
+            return []
 
 
 # 全局单例

--- a/reply_server.py
+++ b/reply_server.py
@@ -45,6 +45,7 @@ from utils.notification_dispatcher import (
     resolve_verification_type_label,
 )
 from order_event_hub import order_event_hub, publish_order_update_event
+from chat_event_hub import chat_event_hub, publish_chat_message
 
 from loguru import logger
 
@@ -9732,6 +9733,300 @@ def stream_user_orders(current_user: Dict[str, Any] = Depends(get_current_user))
             'X-Accel-Buffering': 'no',
         }
     )
+
+
+# ==================== 在线客服 Chat API ====================
+
+@app.get('/api/chat/sessions')
+def get_chat_sessions(
+    cookie_id: str = None,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """获取指定账号的会话列表"""
+    try:
+        if not cookie_id:
+            raise HTTPException(status_code=400, detail="缺少 cookie_id 参数")
+        cookie_id = _ensure_cookie_access(cookie_id, current_user)
+        from db_manager import db_manager
+        sessions = db_manager.get_chat_sessions(cookie_id)
+        return {"success": True, "sessions": sessions}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"获取会话列表失败: {mask_sensitive_text(e)}")
+        raise HTTPException(status_code=500, detail="获取会话列表失败")
+
+
+@app.get('/api/chat/messages')
+def get_chat_messages(
+    cookie_id: str = None,
+    chat_id: str = None,
+    limit: int = 50,
+    before_id: int = None,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """获取指定会话的消息列表"""
+    try:
+        if not cookie_id or not chat_id:
+            raise HTTPException(status_code=400, detail="缺少 cookie_id 或 chat_id 参数")
+        cookie_id = _ensure_cookie_access(cookie_id, current_user)
+        from db_manager import db_manager
+        messages = db_manager.get_chat_messages(cookie_id, chat_id, limit=min(limit, 100), before_id=before_id)
+        return {"success": True, "messages": messages}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"获取聊天消息失败: {mask_sensitive_text(e)}")
+        raise HTTPException(status_code=500, detail="获取聊天消息失败")
+
+
+class ChatSendRequest(BaseModel):
+    cookie_id: str
+    chat_id: str
+    to_user_id: str
+    message: str
+
+
+@app.post('/api/chat/send')
+async def chat_send_message(
+    req: ChatSendRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """在线客服发送消息"""
+    try:
+        cookie_id = _ensure_cookie_access(req.cookie_id, current_user)
+
+        from XianyuAutoAsync import XianyuLive, ConnectionState
+        live_instance = XianyuLive.get_instance(cookie_id)
+        if not live_instance:
+            raise HTTPException(status_code=400, detail="账号未启动")
+        if live_instance.connection_state != ConnectionState.CONNECTED:
+            raise HTTPException(status_code=400, detail="账号WebSocket未连接")
+        if not live_instance.ws:
+            raise HTTPException(status_code=400, detail="WebSocket连接未就绪")
+
+        await _run_live_instance_on_manager_loop(
+            cookie_id,
+            lambda: live_instance.send_msg(
+                live_instance.ws, req.chat_id, req.to_user_id, req.message
+            ),
+            timeout=15,
+        )
+
+        # 保存到数据库并推送SSE
+        from db_manager import db_manager
+        msg_id = db_manager.save_chat_message(
+            cookie_id=cookie_id, chat_id=req.chat_id,
+            sender_id=getattr(live_instance, 'myid', ''),
+            sender_name=cookie_id,
+            content=req.message, content_type=1,
+            direction=1, reply_source='客服'
+        )
+        publish_chat_message(cookie_id, {
+            "msg_id": msg_id, "chat_id": req.chat_id,
+            "sender_id": getattr(live_instance, 'myid', ''),
+            "sender_name": cookie_id,
+            "content": req.message, "content_type": 1,
+            "direction": 1, "reply_source": "客服",
+        })
+
+        return {"success": True, "message": "发送成功", "msg_id": msg_id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"客服发送消息失败: {mask_sensitive_text(e)}")
+        raise HTTPException(status_code=500, detail="发送消息失败")
+
+
+@app.get('/api/chat/stream')
+def stream_chat_messages(current_user: Dict[str, Any] = Depends(get_current_user)):
+    """聊天消息实时事件流"""
+    user_id = current_user['user_id']
+    subscriber = chat_event_hub.subscribe(user_id)
+
+    def event_generator():
+        try:
+            yield format_sse_event('stream.ready', {'type': 'stream.ready', 'timestamp': int(time.time() * 1000)})
+            while True:
+                try:
+                    event = subscriber.get(timeout=25)
+                    yield format_sse_event(event.get('type', 'chat.message'), event)
+                except queue.Empty:
+                    yield format_sse_event('ping', {'type': 'ping', 'timestamp': int(time.time() * 1000)})
+        finally:
+            chat_event_hub.unsubscribe(user_id, subscriber)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type='text/event-stream',
+        headers={
+            'Cache-Control': 'no-cache',
+            'Connection': 'keep-alive',
+            'X-Accel-Buffering': 'no',
+        }
+    )
+
+
+@app.get('/api/chat/accounts')
+def get_chat_accounts(current_user: Dict[str, Any] = Depends(get_current_user)):
+    """获取当前用户的所有账号列表（在线客服三栏布局用）"""
+    try:
+        user_cookies = _get_user_cookies_map(current_user)
+        accounts = []
+        for cid, cookie_data in user_cookies.items():
+            status = _build_live_runtime_status(cid)
+            detail = db_manager.get_cookie_details(cid) or {}
+            display_name = detail.get('remark') or detail.get('username') or cid
+            accounts.append({
+                'id': cid,
+                'name': display_name,
+                'enabled': db_manager.get_cookie_status(cid),
+                'connected': status.get('connection_state') == 'connected' if status else False,
+            })
+        return {"success": True, "accounts": accounts}
+    except Exception as e:
+        logger.error(f"获取聊天账号列表失败: {mask_sensitive_text(e)}")
+        raise HTTPException(status_code=500, detail="获取账号列表失败")
+
+
+@app.get('/api/chat/keywords/{cid}/item/{item_id}')
+def get_item_keywords(
+    cid: str, item_id: str,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """获取指定商品的关键词列表"""
+    try:
+        cid = _ensure_cookie_access(cid, current_user)
+        from db_manager import db_manager
+        keywords = db_manager.get_keywords_by_item_id(cid, item_id)
+        # 同时获取 item_replay 表的指定商品回复
+        item_reply = None
+        try:
+            cursor = db_manager.conn.cursor()
+            db_manager._execute_sql(cursor,
+                "SELECT reply_content FROM item_replay WHERE cookie_id = ? AND item_id = ?",
+                (cid, item_id))
+            row = cursor.fetchone()
+            if row:
+                item_reply = row[0]
+        except Exception:
+            pass
+        return {"success": True, "keywords": keywords, "item_reply": item_reply}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"获取商品关键词失败: {mask_sensitive_text(e)}")
+        raise HTTPException(status_code=500, detail="获取商品关键词失败")
+
+
+class SaveItemKeywordsRequest(BaseModel):
+    keywords: list  # [{"keyword": str, "reply": str, "type": "text"|"image", "image_url": str|None}]
+    item_reply: Optional[str] = None  # 指定商品回复内容
+
+
+@app.post('/api/chat/keywords/{cid}/item/{item_id}')
+def save_item_keywords(
+    cid: str, item_id: str,
+    req: SaveItemKeywordsRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """保存指定商品的关键词和指定商品回复"""
+    try:
+        cid = _ensure_cookie_access(cid, current_user)
+        from db_manager import db_manager
+        success = db_manager.save_keywords_for_item(cid, item_id, req.keywords)
+        # 同时更新 item_replay
+        if req.item_reply is not None:
+            try:
+                cursor = db_manager.conn.cursor()
+                if req.item_reply.strip():
+                    db_manager._execute_sql(cursor, """
+                        INSERT INTO item_replay (cookie_id, item_id, reply_content)
+                        VALUES (?, ?, ?)
+                        ON CONFLICT(cookie_id, item_id) DO UPDATE SET
+                            reply_content = excluded.reply_content,
+                            updated_at = CURRENT_TIMESTAMP
+                    """, (cid, item_id, req.item_reply))
+                else:
+                    db_manager._execute_sql(cursor,
+                        "DELETE FROM item_replay WHERE cookie_id = ? AND item_id = ?",
+                        (cid, item_id))
+                db_manager.conn.commit()
+            except Exception as ie:
+                logger.error(f"更新指定商品回复失败: {mask_sensitive_text(ie)}")
+        return {"success": success, "count": len(req.keywords)}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"保存商品关键词失败: {mask_sensitive_text(e)}")
+        raise HTTPException(status_code=500, detail="保存商品关键词失败")
+
+
+class CopyKeywordsRequest(BaseModel):
+    source_item_id: str
+    target_item_ids: List[str]
+
+
+@app.post('/api/chat/keywords/{cid}/copy')
+def copy_item_keywords(
+    cid: str,
+    req: CopyKeywordsRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """复制商品关键词和指定商品回复到其他商品"""
+    try:
+        cid = _ensure_cookie_access(cid, current_user)
+        from db_manager import db_manager
+        results = {}
+        # 获取源商品的指定商品回复
+        source_reply = None
+        try:
+            source_item = db_manager.get_item_replay_by_cookie_and_id(cid, req.source_item_id)
+            if source_item:
+                source_reply = source_item.get('reply_content', '')
+        except Exception:
+            pass
+        for target in req.target_item_ids:
+            if target == req.source_item_id:
+                continue
+            count = db_manager.copy_keywords_to_item(cid, req.source_item_id, target)
+            results[target] = count
+            # 同时复制指定商品回复
+            if source_reply:
+                try:
+                    db_manager.update_item_reply(cid, target, source_reply)
+                except Exception:
+                    pass
+        return {"success": True, "results": results, "total": sum(results.values())}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"复制商品关键词失败: {mask_sensitive_text(e)}")
+        raise HTTPException(status_code=500, detail="复制商品关键词失败")
+
+
+@app.get('/api/chat/items/{cid}')
+def get_account_items(
+    cid: str,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """获取账号下的商品列表（用于复制回复的目标选择）"""
+    try:
+        cid = _ensure_cookie_access(cid, current_user)
+        from db_manager import db_manager
+        cursor = db_manager.conn.cursor()
+        db_manager._execute_sql(cursor, """
+            SELECT item_id, item_title FROM item_info
+            WHERE cookie_id = ? ORDER BY item_id
+        """, (cid,))
+        rows = cursor.fetchall()
+        items = [{"item_id": r[0], "item_title": r[1]} for r in rows]
+        return {"success": True, "items": items}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"获取商品列表失败: {mask_sensitive_text(e)}")
+        raise HTTPException(status_code=500, detail="获取商品列表失败")
 
 
 @app.delete('/api/orders/{order_id}')

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -289,18 +289,287 @@ body.sidebar-collapsed .main-content {
   display: block;
 }
 
-/* 在线客服页面特殊样式 - 使用flex布局填满高度 */
+/* 在线客服页面 - 三栏布局 */
 #online-im-section.active {
   display: flex;
   flex-direction: column;
   height: calc(100vh);
 }
-
-#online-im-section .content-header {
-  flex-shrink: 0;
-}
-
 #online-im-section .content-body {
   flex: 1;
   overflow: hidden;
+}
+
+/* 三栏通用面板头部 */
+.chat-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  font-weight: 600;
+  font-size: 13px;
+  border-bottom: 1px solid var(--bs-border-color, #dee2e6);
+  flex-shrink: 0;
+  background: var(--bs-body-bg, #fff);
+}
+.chat-panel-body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+/* 第1栏：账号列表 */
+.chat-account-list {
+  width: 180px;
+  min-width: 180px;
+  border-right: 1px solid var(--bs-border-color, #dee2e6);
+  display: flex;
+  flex-direction: column;
+  background: var(--bs-body-bg, #fff);
+}
+.chat-account-item {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--bs-border-color, #f0f0f0);
+  font-size: 13px;
+  transition: background 0.15s;
+  gap: 8px;
+}
+.chat-account-item:hover {
+  background: var(--bs-tertiary-bg, #f8f9fa);
+}
+.chat-account-item.active {
+  background: var(--bs-primary-bg-subtle, #e7f1ff);
+  font-weight: 600;
+}
+.chat-account-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.chat-account-dot.online { background: #28a745; }
+.chat-account-dot.offline { background: #ccc; }
+.chat-account-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* 第2栏：会话列表 */
+.chat-session-list {
+  width: 260px;
+  min-width: 260px;
+  border-right: 1px solid var(--bs-border-color, #dee2e6);
+  display: flex;
+  flex-direction: column;
+  background: var(--bs-body-bg, #fff);
+}
+.chat-session-item {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--bs-border-color, #f0f0f0);
+  transition: background 0.15s;
+}
+.chat-session-item:hover {
+  background: var(--bs-tertiary-bg, #f8f9fa);
+}
+.chat-session-item.active {
+  background: var(--bs-primary-bg-subtle, #e7f1ff);
+  border-left: 3px solid var(--bs-primary, #0d6efd);
+}
+.chat-session-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bs-secondary-bg, #e9ecef);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  color: var(--bs-secondary-color, #6c757d);
+  flex-shrink: 0;
+  font-size: 13px;
+}
+.chat-session-info {
+  flex: 1;
+  min-width: 0;
+  margin-left: 10px;
+}
+.chat-session-name {
+  font-weight: 600;
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.chat-session-preview {
+  font-size: 12px;
+  color: var(--bs-secondary-color, #6c757d);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+.chat-session-time {
+  font-size: 11px;
+  color: var(--bs-secondary-color, #999);
+  flex-shrink: 0;
+  margin-left: 6px;
+  align-self: flex-start;
+}
+
+/* 第3栏：聊天主区域 */
+.chat-main-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--bs-body-bg, #fff);
+}
+.chat-active-area {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.chat-msg-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.chat-header {
+  flex-shrink: 0;
+  background: var(--bs-body-bg, #fff);
+}
+.chat-messages-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  background: var(--bs-tertiary-bg, #f5f5f5);
+}
+.chat-input-area {
+  flex-shrink: 0;
+  background: var(--bs-body-bg, #fff);
+}
+
+/* 右侧回复编辑面板 */
+.chat-reply-panel {
+  width: 320px;
+  min-width: 320px;
+  border-left: 1px solid var(--bs-border-color, #dee2e6);
+  display: flex;
+  flex-direction: column;
+  background: var(--bs-body-bg, #fff);
+}
+.chat-reply-body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+/* 关键词行 */
+.kw-row {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 6px;
+  align-items: flex-start;
+}
+.kw-row input { font-size: 12px; }
+.kw-row .btn { font-size: 11px; padding: 2px 6px; }
+
+/* 消息气泡 */
+.chat-msg-row {
+  display: flex;
+  margin-bottom: 16px;
+  padding: 0 8px;
+}
+.chat-msg-row.incoming { justify-content: flex-start; }
+.chat-msg-row.outgoing { justify-content: flex-end; }
+/* 包裹气泡和时间的容器 —— 宽度约束在这一层 */
+.chat-msg-row > div {
+  max-width: 65%;
+}
+.chat-msg-bubble {
+  display: inline-block;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-size: 14px;
+  line-height: 1.6;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+.chat-msg-row.incoming .chat-msg-bubble {
+  background: var(--bs-body-bg, #fff);
+  border: 1px solid var(--bs-border-color, #e0e0e0);
+  border-top-left-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+}
+.chat-msg-row.outgoing .chat-msg-bubble {
+  background: #fff3cd;
+  border: 1px solid #ffe69c;
+  border-top-right-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+}
+.chat-msg-meta {
+  font-size: 11px;
+  color: var(--bs-secondary-color, #999);
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.chat-msg-row.incoming .chat-msg-meta { justify-content: flex-start; }
+.chat-msg-row.outgoing .chat-msg-meta { justify-content: flex-end; }
+.chat-msg-image {
+  max-width: 200px;
+  max-height: 200px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.chat-msg-source {
+  display: inline-block;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--bs-info-bg-subtle, #e0f7fa);
+  color: var(--bs-info-text-emphasis, #0288d1);
+}
+.chat-date-divider {
+  text-align: center;
+  margin: 12px 0;
+  font-size: 12px;
+  color: var(--bs-secondary-color, #999);
+}
+.chat-date-divider span {
+  background: var(--bs-tertiary-bg, #f5f5f5);
+  padding: 2px 12px;
+  border-radius: 10px;
+}
+
+/* 复用目标商品列表 */
+.copy-target-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0;
+  font-size: 12px;
+}
+.copy-target-item label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+  margin: 0;
+}
+
+@media (max-width: 992px) {
+  .chat-account-list { width: 140px; min-width: 140px; }
+  .chat-session-list { width: 200px; min-width: 200px; }
+  .chat-reply-panel { width: 260px; min-width: 260px; }
+  .chat-msg-row > div { max-width: 80%; }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -2507,59 +2507,102 @@
 
     <!-- 在线客服内容 -->
     <div id="online-im-section" class="content-section">
-      <div class="content-header" style="flex-shrink: 0;">
-        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
-          <div>
-            <h2 class="mb-0">
-              <i class="bi bi-headset me-2"></i>
-              在线客服
-            </h2>
-            <p class="text-muted mb-0">内嵌闲鱼IM页面，快速处理客户咨询</p>
+      <div class="content-body p-0" style="flex: 1; overflow: hidden;">
+        <div class="d-flex h-100" id="chatContainer">
+          <!-- 第1栏：账号列表 -->
+          <div class="chat-account-list" id="chatAccountList">
+            <div class="chat-panel-header">
+              <span>账号列表</span>
+              <button class="btn btn-link btn-sm p-0" onclick="refreshChatAccounts()" title="刷新"><i class="bi bi-arrow-clockwise"></i></button>
+            </div>
+            <div class="chat-panel-body" id="chatAccountsBody">
+              <div class="text-center text-muted py-4 small">加载中...</div>
+            </div>
           </div>
-          <div class="d-flex align-items-center gap-2 flex-wrap">
-            <select class="form-select form-select-sm" id="imAccountSelect" style="width: auto; min-width: 150px;" onchange="onImAccountChange()">
-              <option value="">-- 选择账号 --</option>
-            </select>
-            <!-- 账号密码信息显示在选择框旁边 -->
-            <div id="imAccountInfoBar" class="d-flex flex-column gap-1">
-              <div class="d-flex align-items-center gap-1">
-                <span class="text-muted small">账号:</span>
-                <code id="imDisplayUsername" class="bg-light px-2 py-1 rounded small text-center" style="min-width: 120px; display: inline-block;">-</code>
-                <button class="btn btn-link btn-sm p-0 text-primary" onclick="copyImUsername()" title="复制账号">
-                  <i class="bi bi-clipboard"></i>
-                </button>
-              </div>
-              <div class="d-flex align-items-center gap-1">
-                <span class="text-muted small">密码:</span>
-                <code id="imDisplayPassword" class="bg-light px-2 py-1 rounded small text-center" style="min-width: 120px; display: inline-block;">-</code>
-                <button class="btn btn-link btn-sm p-0 text-primary" onclick="copyImPassword()" title="复制密码">
-                  <i class="bi bi-clipboard"></i>
-                </button>
+          <!-- 第2栏：会话列表 -->
+          <div class="chat-session-list" id="chatSessionList">
+            <div class="chat-panel-header">
+              <span>会话列表</span>
+              <button class="btn btn-link btn-sm p-0" onclick="refreshChatSessions()" title="刷新"><i class="bi bi-arrow-clockwise"></i></button>
+            </div>
+            <div class="p-2 border-bottom">
+              <input type="text" class="form-control form-control-sm" id="chatSearchInput" placeholder="搜索会话..." oninput="filterChatSessions()">
+            </div>
+            <div class="chat-panel-body" id="chatSessionsBody">
+              <div class="text-center text-muted py-4 small">请先选择账号</div>
+            </div>
+          </div>
+          <!-- 第3栏：聊天区域 -->
+          <div class="chat-main-area" id="chatMainArea">
+            <div class="chat-main-placeholder d-flex flex-column align-items-center justify-content-center h-100 text-muted" id="chatMainPlaceholder">
+              <i class="bi bi-chat-square-text" style="font-size: 3rem;"></i>
+              <p class="mt-2">请选择一个会话查看聊天记录</p>
+            </div>
+            <div class="chat-active-area d-none" id="chatActiveArea">
+              <div class="d-flex h-100">
+                <!-- 左：聊天消息 -->
+                <div class="chat-msg-panel">
+                  <div class="chat-header border-bottom px-3 py-2 d-flex align-items-center justify-content-between">
+                    <div>
+                      <strong id="chatHeaderName">-</strong>
+                      <small class="text-muted ms-2" id="chatHeaderItemId"></small>
+                    </div>
+                    <div class="d-flex gap-1">
+                      <button class="btn btn-sm btn-outline-secondary" onclick="loadMoreChatMessages()" title="加载更多"><i class="bi bi-clock-history"></i></button>
+                      <button class="btn btn-sm btn-outline-primary" onclick="toggleReplyPanel()" title="商品回复" id="btnToggleReply"><i class="bi bi-chat-right-text"></i></button>
+                    </div>
+                  </div>
+                  <div class="chat-messages-area" id="chatMessagesArea"></div>
+                  <div class="chat-input-area border-top p-2">
+                    <div class="d-flex gap-2">
+                      <textarea class="form-control form-control-sm" id="chatInputBox" rows="2" placeholder="输入消息... (Enter发送, Shift+Enter换行)" onkeydown="handleChatInputKeydown(event)"></textarea>
+                      <button class="btn btn-primary btn-sm align-self-end" onclick="sendChatMessage()" id="chatSendBtn" style="min-width: 60px;">发送</button>
+                    </div>
+                  </div>
+                </div>
+                <!-- 右：商品回复编辑面板 -->
+                <div class="chat-reply-panel d-none" id="chatReplyPanel">
+                  <div class="chat-panel-header">
+                    <span>商品回复设置</span>
+                    <button class="btn btn-link btn-sm p-0" onclick="toggleReplyPanel()" title="关闭"><i class="bi bi-x-lg"></i></button>
+                  </div>
+                  <div class="chat-reply-body" id="chatReplyBody">
+                    <div class="p-3">
+                      <!-- 商品信息 -->
+                      <div class="mb-3">
+                        <label class="form-label fw-bold small">当前商品</label>
+                        <div class="input-group input-group-sm">
+                          <span class="input-group-text">ID</span>
+                          <input type="text" class="form-control" id="replyItemId" readonly>
+                        </div>
+                      </div>
+                      <!-- 指定商品回复 -->
+                      <div class="mb-3">
+                        <label class="form-label fw-bold small">指定商品回复 <span class="text-muted fw-normal">(优先级最高)</span></label>
+                        <textarea class="form-control form-control-sm" id="replyItemReply" rows="2" placeholder="输入该商品的固定回复..."></textarea>
+                      </div>
+                      <!-- 商品关键词列表 -->
+                      <div class="mb-3">
+                        <div class="d-flex justify-content-between align-items-center mb-1">
+                          <label class="form-label fw-bold small mb-0">商品关键词</label>
+                          <button class="btn btn-outline-primary btn-sm" onclick="addKeywordRow()" style="font-size:11px;"><i class="bi bi-plus"></i> 添加</button>
+                        </div>
+                        <div id="replyKeywordsList"></div>
+                      </div>
+                      <!-- 保存按钮 -->
+                      <button class="btn btn-primary btn-sm w-100 mb-3" onclick="saveItemKeywords()"><i class="bi bi-check-lg me-1"></i>保存回复设置</button>
+                      <!-- 复用回复 -->
+                      <div class="border-top pt-3">
+                        <label class="form-label fw-bold small">一键复用到其他商品</label>
+                        <div id="copyTargetItems" class="mb-2" style="max-height: 150px; overflow-y: auto;"></div>
+                        <button class="btn btn-outline-success btn-sm w-100" onclick="copyKeywordsToSelected()"><i class="bi bi-files me-1"></i>复制到选中商品</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
-            <button class="btn btn-sm btn-outline-secondary" onclick="loadImAccountList()" title="刷新账号列表">
-              <i class="bi bi-arrow-clockwise"></i>
-            </button>
-            <button class="btn btn-sm btn-outline-success" onclick="refreshImIframe()" title="刷新页面">
-              <i class="bi bi-arrow-repeat"></i> 刷新
-            </button>
-            <button class="btn btn-sm btn-success" onclick="openGoofishImNewWindow()" title="在新窗口打开">
-              <i class="bi bi-box-arrow-up-right"></i> 新窗口
-            </button>
           </div>
-        </div>
-      </div>
-      <div class="content-body p-0" style="flex: 1; overflow: hidden;">
-        <!-- 内嵌闲鱼IM iframe -->
-        <div class="im-iframe-container" style="height: 100%;">
-          <iframe
-            id="goofishImIframe"
-            src="about:blank"
-            data-src="https://www.goofish.com/im"
-            style="width: 100%; height: 100%; border: none;"
-            allow="microphone; camera; clipboard-read; clipboard-write"
-            sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads"
-          ></iframe>
         </div>
       </div>
     </div>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -19771,262 +19771,540 @@ hotUpdateStyle.textContent = `
 `;
 document.head.appendChild(hotUpdateStyle);
 
-// ==================== 在线客服IM功能 ====================
+// ==================== 在线客服聊天功能（三栏布局） ====================
 
-// 存储IM账号数据
-let imAccountsData = [];
+let chatCurrentCookieId = '';
+let chatCurrentChatId = '';
+let chatCurrentToUserId = '';
+let chatCurrentSenderName = '';
+let chatCurrentItemId = '';
+let chatSessionsCache = [];
+let chatOldestMsgId = null;
+let chatSseAbortController = null;
+let chatSseRetryCount = 0;
+let chatSseShouldRun = false;
 
-/**
- * 加载IM账号列表
- */
-async function loadImAccountList() {
+// === 第1栏：账号列表 ===
+async function refreshChatAccounts() {
+    const body = document.getElementById('chatAccountsBody');
+    if (!body) return;
+    body.innerHTML = '<div class="text-center text-muted py-4 small"><div class="spinner-border spinner-border-sm"></div></div>';
     try {
-        // 重置账号密码显示为默认值
-        const usernameEl = document.getElementById('imDisplayUsername');
-        const passwordEl = document.getElementById('imDisplayPassword');
-        if (usernameEl) usernameEl.textContent = '-';
-        if (passwordEl) passwordEl.textContent = '-';
-
-        const response = await fetch(`${apiBase}/cookies/details`, {
-            headers: {
-                'Authorization': `Bearer ${authToken}`
-            }
+        const resp = await fetch(`${apiBase}/api/chat/accounts`, {
+            headers: { 'Authorization': `Bearer ${authToken}` }
         });
-
-        if (response.ok) {
-            const data = await response.json();
-            imAccountsData = data || [];
-
-            const select = document.getElementById('imAccountSelect');
-            if (select) {
-                select.innerHTML = '<option value="">-- 选择账号 --</option>';
-
-                imAccountsData.forEach(account => {
-                    const option = document.createElement('option');
-                    option.value = account.id;
-                    option.textContent = account.id;
-                    // 仅缓存非敏感账号信息，敏感字段按需拉取
-                    option.dataset.username = account.username || '';
-                    select.appendChild(option);
-                });
+        const result = await resp.json();
+        if (result.success) {
+            const accounts = result.accounts || [];
+            if (accounts.length === 0) {
+                body.innerHTML = '<div class="text-center text-muted py-4 small">暂无可用账号</div>';
+                return;
             }
+            body.innerHTML = '';
+            accounts.forEach(a => {
+                const div = document.createElement('div');
+                div.className = 'chat-account-item' + (a.id === chatCurrentCookieId ? ' active' : '');
+                div.innerHTML = `<div class="chat-account-dot ${a.connected ? 'online' : 'offline'}"></div><div class="chat-account-name" title="${escapeHtml(a.id)}">${escapeHtml(a.name || a.id)}</div>`;
+                div.onclick = () => selectChatAccount(a.id);
+                body.appendChild(div);
+            });
         } else {
-            console.error('加载IM账号列表失败:', response.status);
+            body.innerHTML = '<div class="text-center text-muted py-4 small">加载失败</div>';
         }
-    } catch (error) {
-        console.error('加载IM账号列表失败:', error);
+    } catch (e) {
+        console.error('加载账号列表失败:', e);
+        body.innerHTML = '<div class="text-center text-muted py-4 small">加载失败</div>';
     }
 }
 
-/**
- * 账号选择变化时的处理
- */
-async function fetchImAccountDetails(accountId) {
-    const response = await fetch(`${apiBase}/cookie/${encodeURIComponent(accountId)}/details?include_secrets=true`, {
-        headers: {
-            'Authorization': `Bearer ${authToken}`
+async function selectChatAccount(cookieId) {
+    chatCurrentCookieId = cookieId;
+    chatCurrentChatId = '';
+    chatCurrentToUserId = '';
+    chatCurrentItemId = '';
+    // 高亮
+    document.querySelectorAll('.chat-account-item').forEach(el => {
+        el.classList.toggle('active', el.querySelector('.chat-account-name')?.textContent === cookieId);
+    });
+    // 重置右侧
+    const placeholder = document.getElementById('chatMainPlaceholder');
+    const active = document.getElementById('chatActiveArea');
+    if (placeholder) placeholder.classList.remove('d-none');
+    if (active) active.classList.add('d-none');
+    hideReplyPanel();
+    await refreshChatSessions();
+}
+
+// === 第2栏：会话列表 ===
+async function refreshChatSessions() {
+    if (!chatCurrentCookieId) return;
+    const body = document.getElementById('chatSessionsBody');
+    if (body) body.innerHTML = '<div class="text-center text-muted py-4 small"><div class="spinner-border spinner-border-sm"></div></div>';
+    try {
+        const resp = await fetch(`${apiBase}/api/chat/sessions?cookie_id=${encodeURIComponent(chatCurrentCookieId)}`, {
+            headers: { 'Authorization': `Bearer ${authToken}` }
+        });
+        const result = await resp.json();
+        if (result.success) {
+            chatSessionsCache = result.sessions || [];
+            renderChatSessions(chatSessionsCache);
+        } else {
+            if (body) body.innerHTML = '<div class="text-center text-muted py-4 small">加载失败</div>';
         }
+    } catch (e) {
+        console.error('获取会话列表失败:', e);
+        if (body) body.innerHTML = '<div class="text-center text-muted py-4 small">加载失败</div>';
+    }
+}
+
+function renderChatSessions(sessions) {
+    const body = document.getElementById('chatSessionsBody');
+    if (!body) return;
+    if (!sessions.length) {
+        body.innerHTML = '<div class="text-center text-muted py-4 small">暂无会话</div>';
+        return;
+    }
+    body.innerHTML = '';
+    sessions.forEach(s => {
+        const div = document.createElement('div');
+        div.className = 'chat-session-item' + (s.chat_id === chatCurrentChatId ? ' active' : '');
+        const displayName = s.buyer_name || (s.direction === 2 ? (s.sender_name || s.sender_id || s.chat_id) : (s.sender_name || s.chat_id));
+        const avatar = (displayName || '?').charAt(0).toUpperCase();
+        const preview = s.content_type === 2 ? '[图片]' : (s.content || '').substring(0, 25);
+        div.innerHTML = `
+            <div class="chat-session-avatar">${escapeHtml(avatar)}</div>
+            <div class="chat-session-info">
+                <div class="chat-session-name">${escapeHtml(displayName)}</div>
+                <div class="chat-session-preview">${escapeHtml(preview)}</div>
+            </div>
+            <div class="chat-session-time">${escapeHtml(formatChatTime(s.created_at))}</div>
+        `;
+        div.onclick = () => selectChatSession(s);
+        body.appendChild(div);
+    });
+}
+
+function filterChatSessions() {
+    const kw = (document.getElementById('chatSearchInput')?.value || '').toLowerCase();
+    if (!kw) { renderChatSessions(chatSessionsCache); return; }
+    renderChatSessions(chatSessionsCache.filter(s =>
+        (s.sender_name || '').toLowerCase().includes(kw) ||
+        (s.chat_id || '').includes(kw) ||
+        (s.content || '').toLowerCase().includes(kw)
+    ));
+}
+
+// === 第3栏：聊天区域 ===
+async function selectChatSession(session) {
+    chatCurrentChatId = session.chat_id;
+    chatCurrentToUserId = session.buyer_id || (session.direction === 2 ? (session.sender_id || '') : '');
+    chatCurrentSenderName = session.buyer_name || (session.direction === 2 ? (session.sender_name || session.sender_id || session.chat_id) : (session.sender_name || session.chat_id));
+    chatCurrentItemId = session.item_id || '';
+    chatOldestMsgId = null;
+
+    document.querySelectorAll('.chat-session-item').forEach(el => {
+        el.classList.toggle('active', el.querySelector('.chat-session-info')?.querySelector('.chat-session-name')?.textContent === chatCurrentSenderName);
     });
 
-    if (!response.ok) {
-        throw new Error('获取账号详情失败');
-    }
+    const placeholder = document.getElementById('chatMainPlaceholder');
+    const active = document.getElementById('chatActiveArea');
+    if (placeholder) placeholder.classList.add('d-none');
+    if (active) active.classList.remove('d-none');
 
-    return await response.json();
-}
+    document.getElementById('chatHeaderName').textContent = chatCurrentSenderName;
+    document.getElementById('chatHeaderItemId').textContent = chatCurrentItemId ? `商品: ${chatCurrentItemId}` : '';
 
-/**
- * 账号选择变化时的处理
- */
-async function onImAccountChange() {
-    const select = document.getElementById('imAccountSelect');
-    const usernameEl = document.getElementById('imDisplayUsername');
-    const passwordEl = document.getElementById('imDisplayPassword');
+    await loadChatMessages();
 
-    if (!select) return;
-
-    const selectedOption = select.selectedOptions[0];
-
-    if (selectedOption && selectedOption.value) {
-        const username = selectedOption.dataset.username || '未配置';
-
-        if (usernameEl) usernameEl.textContent = username;
-        if (passwordEl) {
-            passwordEl.textContent = '加载中...';
-        }
-
-        try {
-            const details = await fetchImAccountDetails(selectedOption.value);
-            const password = details.password || '';
-            if (passwordEl) {
-                passwordEl.textContent = password ? '••••••••' : '未配置';
+    // 从消息中提取买家ID和商品ID
+    try {
+        const resp = await fetch(`${apiBase}/api/chat/messages?cookie_id=${encodeURIComponent(chatCurrentCookieId)}&chat_id=${encodeURIComponent(chatCurrentChatId)}&limit=50`, {
+            headers: { 'Authorization': `Bearer ${authToken}` }
+        });
+        const result = await resp.json();
+        if (result.success && result.messages) {
+            const buyerMsg = result.messages.find(m => m.direction === 2);
+            if (buyerMsg) {
+                if (!chatCurrentToUserId) chatCurrentToUserId = buyerMsg.sender_id;
+                if (!chatCurrentSenderName || chatCurrentSenderName === chatCurrentChatId) {
+                    chatCurrentSenderName = buyerMsg.sender_name || buyerMsg.sender_id;
+                    document.getElementById('chatHeaderName').textContent = chatCurrentSenderName;
+                }
             }
-        } catch (error) {
-            if (passwordEl) {
-                passwordEl.textContent = '获取失败';
+            // 提取最新的商品ID
+            const msgWithItem = [...result.messages].reverse().find(m => m.item_id && m.item_id !== 'None' && !m.item_id.startsWith('auto_'));
+            if (msgWithItem) {
+                chatCurrentItemId = msgWithItem.item_id;
+                document.getElementById('chatHeaderItemId').textContent = `商品: ${chatCurrentItemId}`;
             }
-            console.error('获取IM账号详情失败:', error);
-            showToast('获取账号密码失败，请稍后重试', 'warning');
         }
-    } else {
-        // 未选择账号时显示默认值
-        if (usernameEl) usernameEl.textContent = '-';
-        if (passwordEl) passwordEl.textContent = '-';
+    } catch (e) { /* ignore */ }
+
+    // 自动加载商品回复面板数据（如果面板可见）
+    if (!document.getElementById('chatReplyPanel')?.classList.contains('d-none') && chatCurrentItemId) {
+        loadItemKeywords();
     }
+
+    document.getElementById('chatInputBox')?.focus();
 }
 
-/**
- * 复制账号到剪贴板
- */
-async function copyImUsername() {
-    const usernameEl = document.getElementById('imDisplayUsername');
-    const username = usernameEl ? usernameEl.textContent : '';
-
-    if (!username || username === '未配置' || username === '-') {
-        showToast('账号未配置', 'warning');
-        return;
-    }
+async function loadChatMessages(append = false) {
+    if (!chatCurrentCookieId || !chatCurrentChatId) return;
+    const area = document.getElementById('chatMessagesArea');
+    if (!area) return;
+    if (!append) area.innerHTML = '<div class="text-center text-muted py-4"><div class="spinner-border spinner-border-sm"></div></div>';
 
     try {
-        await navigator.clipboard.writeText(username);
-        showToast('账号已复制', 'success');
-    } catch (error) {
-        fallbackCopy(username, '账号已复制', '复制失败');
-    }
-}
-
-/**
- * 复制密码到剪贴板
- */
-async function copyImPassword() {
-    const select = document.getElementById('imAccountSelect');
-    if (!select || !select.value) {
-        showToast('请先选择账号', 'warning');
-        return;
-    }
-
-    let password = '';
-
-    try {
-        const details = await fetchImAccountDetails(select.value);
-        password = details.password || '';
-    } catch (error) {
-        console.error('获取密码失败:', error);
-        showToast('获取密码失败，请稍后重试', 'danger');
-        return;
-    }
-
-    if (!password || password === '未配置') {
-        showToast('密码未配置', 'warning');
-        return;
-    }
-
-    try {
-        await navigator.clipboard.writeText(password);
-        showToast('密码已复制', 'success');
-    } catch (error) {
-        fallbackCopy(password, '密码已复制', '复制失败');
-    }
-}
-
-/**
- * 降级复制方案
- */
-function fallbackCopy(text, successMsg, failMsg) {
-    const textArea = document.createElement('textarea');
-    textArea.value = text;
-    textArea.style.position = 'fixed';
-    textArea.style.left = '-9999px';
-    document.body.appendChild(textArea);
-    textArea.select();
-
-    try {
-        document.execCommand('copy');
-        showToast(successMsg, 'success');
+        let url = `${apiBase}/api/chat/messages?cookie_id=${encodeURIComponent(chatCurrentCookieId)}&chat_id=${encodeURIComponent(chatCurrentChatId)}&limit=50`;
+        if (append && chatOldestMsgId) url += `&before_id=${chatOldestMsgId}`;
+        const resp = await fetch(url, { headers: { 'Authorization': `Bearer ${authToken}` } });
+        const result = await resp.json();
+        if (result.success) {
+            const msgs = result.messages || [];
+            if (msgs.length > 0) chatOldestMsgId = msgs[0].id;
+            if (append) {
+                const prevH = area.scrollHeight;
+                area.insertAdjacentHTML('afterbegin', renderChatMessages(msgs));
+                area.scrollTop = area.scrollHeight - prevH;
+            } else {
+                area.innerHTML = msgs.length ? renderChatMessages(msgs) : '<div class="text-center text-muted py-4">暂无消息记录</div>';
+                area.scrollTop = area.scrollHeight;
+            }
+        }
     } catch (e) {
-        showToast(failMsg, 'danger');
+        console.error('加载消息失败:', e);
+        if (!append) area.innerHTML = '<div class="text-center text-muted py-4">加载失败</div>';
     }
-
-    document.body.removeChild(textArea);
 }
 
-/**
- * 复制账号密码到剪贴板（保留兼容）
- */
-async function copyImAccountInfo() {
-    const select = document.getElementById('imAccountSelect');
+function loadMoreChatMessages() { loadChatMessages(true); }
 
-    if (!select || !select.value) {
-        showToast('请先选择一个账号', 'warning');
+function renderChatMessages(messages) {
+    let html = '';
+    let lastDate = '';
+    messages.forEach(m => {
+        const dateStr = (m.created_at || '').substring(0, 10);
+        if (dateStr && dateStr !== lastDate) {
+            lastDate = dateStr;
+            html += `<div class="chat-date-divider"><span>${escapeHtml(dateStr)}</span></div>`;
+        }
+        const isOut = m.direction === 1;
+        const timeStr = (m.created_at || '').substring(11, 16);
+        let contentHtml = '';
+        if (m.content_type === 2 && m.image_url) {
+            contentHtml = `<img src="${escapeHtml(m.image_url)}" class="chat-msg-image" onclick="window.open(this.src,'_blank')">`;
+            if (m.content && m.content !== '[图片]') contentHtml += `<div class="mt-1">${escapeHtml(m.content)}</div>`;
+        } else {
+            contentHtml = escapeHtml(m.content || '').replace(/\n/g, '<br>');
+        }
+        let sourceHtml = m.reply_source ? `<span class="chat-msg-source">${escapeHtml(m.reply_source)}</span>` : '';
+        html += `<div class="chat-msg-row ${isOut ? 'outgoing' : 'incoming'}">
+            <div><div class="chat-msg-bubble">${contentHtml}</div><div class="chat-msg-meta">${escapeHtml(timeStr)}${sourceHtml}</div></div>
+        </div>`;
+    });
+    return html;
+}
+
+async function sendChatMessage() {
+    const input = document.getElementById('chatInputBox');
+    const message = (input?.value || '').trim();
+    if (!message) return;
+    if (!chatCurrentCookieId || !chatCurrentChatId || !chatCurrentToUserId) {
+        showToast('无法发送：缺少会话信息', 'warning');
         return;
     }
+    const btn = document.getElementById('chatSendBtn');
+    if (btn) { btn.disabled = true; btn.textContent = '...'; }
+    try {
+        const resp = await fetch(`${apiBase}/api/chat/send`, {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ cookie_id: chatCurrentCookieId, chat_id: chatCurrentChatId, to_user_id: chatCurrentToUserId, message })
+        });
+        const result = await resp.json();
+        if (result.success) {
+            if (input) input.value = '';
+            // 消息将通过 SSE 推送显示，不再本地重复添加
+        } else {
+            showToast(result.detail || result.message || '发送失败', 'danger');
+        }
+    } catch (e) {
+        showToast('发送消息失败', 'danger');
+    } finally {
+        if (btn) { btn.disabled = false; btn.textContent = '发送'; }
+    }
+}
 
-    const selectedOption = select.selectedOptions[0];
-    const username = selectedOption.dataset.username || '';
-    let password = '';
+function appendChatMessage(msg) {
+    const area = document.getElementById('chatMessagesArea');
+    if (!area) return;
+    const emptyHint = area.querySelector('.text-center.text-muted');
+    if (emptyHint) emptyHint.remove();
+    area.insertAdjacentHTML('beforeend', renderChatMessages([msg]));
+    area.scrollTop = area.scrollHeight;
+}
+
+function handleChatInputKeydown(e) {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendChatMessage(); }
+}
+
+// === SSE 实时消息 ===
+async function initChatSSE() {
+    if (chatSseAbortController) { chatSseAbortController.abort(); chatSseAbortController = null; }
+    chatSseShouldRun = true;
+    chatSseRetryCount = 0;
+    connectChatStream();
+}
+async function connectChatStream() {
+    if (!chatSseShouldRun) return;
+    const controller = new AbortController();
+    chatSseAbortController = controller;
+    try {
+        const response = await fetch(`${apiBase}/api/chat/stream`, {
+            headers: { 'Authorization': `Bearer ${authToken}`, 'Accept': 'text/event-stream' },
+            cache: 'no-store', signal: controller.signal
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        chatSseRetryCount = 0;
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const parts = buffer.split('\n\n');
+            buffer = parts.pop() || '';
+            for (const part of parts) processChatSSEEvent(part);
+        }
+    } catch (e) {
+        if (!controller.signal.aborted) {
+            chatSseRetryCount++;
+            setTimeout(() => connectChatStream(), Math.min(chatSseRetryCount * 3000, 30000));
+        }
+    }
+}
+function processChatSSEEvent(raw) {
+    let eventType = 'message', dataStr = '';
+    for (const line of raw.split('\n')) {
+        if (line.startsWith('event: ')) eventType = line.substring(7).trim();
+        else if (line.startsWith('data: ')) dataStr = line.substring(6);
+    }
+    if (eventType === 'ping' || !dataStr) return;
+    try {
+        const event = JSON.parse(dataStr);
+        const data = event.data || {};
+        data.cookie_id = data.cookie_id || event.cookie_id;
+        if (data.cookie_id === chatCurrentCookieId) {
+            updateSessionFromSSE(data);
+            if (data.chat_id === chatCurrentChatId) {
+                appendChatMessage({
+                    content: data.content, content_type: data.content_type,
+                    image_url: data.image_url, direction: data.direction,
+                    reply_source: data.reply_source,
+                    created_at: new Date().toISOString().replace('T', ' ').substring(0, 19)
+                });
+            }
+        }
+    } catch (err) { console.error('SSE解析失败:', err); }
+}
+function updateSessionFromSSE(data) {
+    const preview = {
+        chat_id: data.chat_id, sender_id: data.sender_id, sender_name: data.sender_name,
+        content: data.content, content_type: data.content_type, item_id: data.item_id,
+        direction: data.direction, created_at: new Date().toISOString().replace('T', ' ').substring(0, 19)
+    };
+    const idx = chatSessionsCache.findIndex(s => s.chat_id === data.chat_id);
+    if (idx >= 0) {
+        chatSessionsCache[idx] = { ...chatSessionsCache[idx], ...preview };
+        chatSessionsCache.unshift(chatSessionsCache.splice(idx, 1)[0]);
+    } else {
+        chatSessionsCache.unshift(preview);
+    }
+    renderChatSessions(chatSessionsCache);
+}
+
+// === 右侧商品回复面板 ===
+function toggleReplyPanel() {
+    const panel = document.getElementById('chatReplyPanel');
+    if (!panel) return;
+    panel.classList.toggle('d-none');
+    if (!panel.classList.contains('d-none') && chatCurrentItemId) {
+        loadItemKeywords();
+    }
+}
+function hideReplyPanel() {
+    document.getElementById('chatReplyPanel')?.classList.add('d-none');
+}
+
+async function loadItemKeywords() {
+    if (!chatCurrentCookieId || !chatCurrentItemId) {
+        document.getElementById('replyItemId').value = '未检测到商品';
+        document.getElementById('replyKeywordsList').innerHTML = '<div class="text-muted small">无商品ID</div>';
+        return;
+    }
+    document.getElementById('replyItemId').value = chatCurrentItemId;
+    document.getElementById('replyKeywordsList').innerHTML = '<div class="text-muted small">加载中...</div>';
 
     try {
-        const details = await fetchImAccountDetails(select.value);
-        password = details.password || '';
-    } catch (error) {
-        console.error('获取账号密码失败:', error);
-        showToast('获取账号密码失败，请稍后重试', 'danger');
+        const resp = await fetch(`${apiBase}/api/chat/keywords/${encodeURIComponent(chatCurrentCookieId)}/item/${encodeURIComponent(chatCurrentItemId)}`, {
+            headers: { 'Authorization': `Bearer ${authToken}` }
+        });
+        const result = await resp.json();
+        if (result.success) {
+            document.getElementById('replyItemReply').value = result.item_reply || '';
+            const kws = result.keywords || [];
+            const list = document.getElementById('replyKeywordsList');
+            list.innerHTML = '';
+            if (kws.length === 0) {
+                list.innerHTML = '<div class="text-muted small">暂无关键词，点击"添加"创建</div>';
+            } else {
+                kws.forEach((kw, i) => addKeywordRowWithData(kw.keyword, kw.reply || ''));
+            }
+            // 加载可复制的商品列表
+            loadCopyTargetItems();
+        }
+    } catch (e) {
+        console.error('加载商品关键词失败:', e);
+        document.getElementById('replyKeywordsList').innerHTML = '<div class="text-danger small">加载失败</div>';
+    }
+}
+
+function addKeywordRow() {
+    addKeywordRowWithData('', '');
+}
+
+function addKeywordRowWithData(keyword, reply) {
+    const list = document.getElementById('replyKeywordsList');
+    if (!list) return;
+    // 清空占位提示
+    const hint = list.querySelector('.text-muted');
+    if (hint) hint.remove();
+    const row = document.createElement('div');
+    row.className = 'kw-row';
+    row.innerHTML = `
+        <input type="text" class="form-control form-control-sm" placeholder="关键词" value="${escapeHtml(keyword)}" style="flex:1;">
+        <input type="text" class="form-control form-control-sm" placeholder="回复内容" value="${escapeHtml(reply)}" style="flex:2;">
+        <button class="btn btn-outline-danger btn-sm" onclick="this.parentElement.remove()" title="删除"><i class="bi bi-trash"></i></button>
+    `;
+    list.appendChild(row);
+}
+
+async function saveItemKeywords() {
+    if (!chatCurrentCookieId || !chatCurrentItemId) {
+        showToast('缺少商品信息', 'warning');
         return;
     }
-
-    if (!username && !password) {
-        showToast('该账号未配置用户名和密码', 'warning');
-        return;
-    }
-
-    const copyText = `账号：${username}\n密码：${password}`;
+    const itemReply = document.getElementById('replyItemReply')?.value || '';
+    const rows = document.querySelectorAll('#replyKeywordsList .kw-row');
+    const keywords = [];
+    rows.forEach(row => {
+        const inputs = row.querySelectorAll('input');
+        const kw = inputs[0]?.value.trim();
+        const rp = inputs[1]?.value.trim();
+        if (kw) keywords.push({ keyword: kw, reply: rp, type: 'text' });
+    });
 
     try {
-        await navigator.clipboard.writeText(copyText);
-        showToast('账号密码已复制到剪贴板', 'success');
-    } catch (error) {
-        fallbackCopy(copyText, '账号密码已复制到剪贴板', '复制失败，请手动复制');
+        const resp = await fetch(`${apiBase}/api/chat/keywords/${encodeURIComponent(chatCurrentCookieId)}/item/${encodeURIComponent(chatCurrentItemId)}`, {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ keywords, item_reply: itemReply })
+        });
+        const result = await resp.json();
+        if (result.success) {
+            showToast(`保存成功，${result.count} 条关键词`, 'success');
+        } else {
+            showToast('保存失败', 'danger');
+        }
+    } catch (e) {
+        showToast('保存失败', 'danger');
     }
 }
 
-/**
- * 刷新IM iframe
- */
-function refreshImIframe() {
-    const iframe = document.getElementById('goofishImIframe');
-    if (iframe) {
-        iframe.src = iframe.src;
-        showToast('页面已刷新', 'success');
+async function loadCopyTargetItems() {
+    if (!chatCurrentCookieId) return;
+    const container = document.getElementById('copyTargetItems');
+    if (!container) return;
+    container.innerHTML = '<div class="text-muted small">加载商品...</div>';
+    try {
+        const resp = await fetch(`${apiBase}/api/chat/items/${encodeURIComponent(chatCurrentCookieId)}`, {
+            headers: { 'Authorization': `Bearer ${authToken}` }
+        });
+        const result = await resp.json();
+        if (result.success) {
+            const items = (result.items || []).filter(i => i.item_id !== chatCurrentItemId);
+            if (items.length === 0) {
+                container.innerHTML = '<div class="text-muted small">无其他商品</div>';
+                return;
+            }
+            container.innerHTML = '';
+            items.forEach(item => {
+                const div = document.createElement('div');
+                div.className = 'copy-target-item';
+                div.innerHTML = `<input type="checkbox" value="${escapeHtml(item.item_id)}" id="ct_${escapeHtml(item.item_id)}"><label for="ct_${escapeHtml(item.item_id)}">${escapeHtml(item.item_title || item.item_id)}</label>`;
+                container.appendChild(div);
+            });
+        } else {
+            container.innerHTML = '<div class="text-muted small">加载失败</div>';
+        }
+    } catch (e) {
+        container.innerHTML = '<div class="text-muted small">加载失败</div>';
     }
 }
 
-/**
- * 在新窗口打开闲鱼IM
- */
-function openGoofishImNewWindow() {
-    window.open('https://www.goofish.com/im', '_blank');
+async function copyKeywordsToSelected() {
+    if (!chatCurrentCookieId || !chatCurrentItemId) {
+        showToast('缺少源商品信息', 'warning');
+        return;
+    }
+    const checks = document.querySelectorAll('#copyTargetItems input[type=checkbox]:checked');
+    const targets = [...checks].map(c => c.value);
+    if (targets.length === 0) {
+        showToast('请先选择目标商品', 'warning');
+        return;
+    }
+    try {
+        const resp = await fetch(`${apiBase}/api/chat/keywords/${encodeURIComponent(chatCurrentCookieId)}/copy`, {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ source_item_id: chatCurrentItemId, target_item_ids: targets })
+        });
+        const result = await resp.json();
+        if (result.success) {
+            showToast(`已复制到 ${targets.length} 个商品，共 ${result.total} 条关键词`, 'success');
+        } else {
+            showToast('复制失败', 'danger');
+        }
+    } catch (e) {
+        showToast('复制失败', 'danger');
+    }
 }
 
-/**
- * 兼容旧版函数名
- */
-function openGoofishIm() {
-    openGoofishImNewWindow();
+// === 工具函数 ===
+function formatChatTime(ts) {
+    if (!ts) return '';
+    const d = new Date(ts.replace(' ', 'T'));
+    if (isNaN(d.getTime())) return (ts || '').substring(11, 16);
+    const now = new Date();
+    if (d.toDateString() === now.toDateString()) return d.toTimeString().substring(0, 5);
+    const y = new Date(now); y.setDate(y.getDate() - 1);
+    if (d.toDateString() === y.toDateString()) return '昨天';
+    return `${d.getMonth() + 1}/${d.getDate()}`;
 }
 
-/**
- * 加载在线客服页面
- */
+// === 入口 ===
 function loadOnlineIm() {
-    loadImAccountList();
-
-    // 延迟加载 iframe，避免页面加载时直接加载闲鱼导致跳转问题
-    const iframe = document.getElementById('goofishImIframe');
-    if (iframe && iframe.src === 'about:blank') {
-        const realSrc = iframe.dataset.src || 'https://www.goofish.com/im';
-        iframe.src = realSrc;
-    }
+    refreshChatAccounts();
+    initChatSSE();
 }
+
+// 兼容旧函数名
+function loadImAccountList() { refreshChatAccounts(); }
+function onImAccountChange() {}
+function refreshImIframe() { refreshChatSessions(); }
+function openGoofishImNewWindow() { window.open('https://www.goofish.com/im', '_blank'); }
+function openGoofishIm() { openGoofishImNewWindow(); }
 
 // ==================== 定时擦亮任务管理 ====================
 


### PR DESCRIPTION
## 背景

原有"在线客服"模块通过 iframe 嵌入 `goofish.com/im`，因浏览器跨域策略导致 cookie 无法传递，功能完全不可用。

## 方案

复用项目已有的 WebSocket 消息管道 + SSE 实时推送，自建聊天 UI，**零额外内存开销**（无需启动 Playwright 浏览器实例）。

## 新增功能

- **三栏聊天布局**：账号列表 | 会话列表 | 聊天区域（支持响应式）
- **实时消息收发**：通过 SSE 推送新消息，复用现有 WebSocket 连接发送
- **商品ID自动提取**：从对话上下文中自动识别当前沟通的商品
- **商品回复快捷编辑**：右侧面板可直接编辑指定商品回复和关键词，与已有"指定商品回复"功能联动（同一张 `item_replay` 表）
- **一键复用规则**：将某商品的回复规则和关键词批量复制到其他商品

## 文件变更

| 文件 | 状态 | 说明 |
|------|------|------|
| `chat_event_hub.py` | **新增** | 聊天消息 Pub/Sub 事件中心（参照 `order_event_hub.py` 设计） |
| `db_manager.py` | 修改 | 新增 `chat_messages` 表、会话列表查询、消息 CRUD、商品关键词管理方法 |
| `XianyuAutoAsync.py` | 修改 | 在消息收发流程中添加钩子：存库 + 推送 SSE |
| `reply_server.py` | 修改 | 新增聊天相关 API 端点（账号列表、会话、消息、发送、SSE流、关键词管理） |
| `static/index.html` | 修改 | 替换在线客服 iframe 为三栏聊天布局 HTML |
| `static/css/layout.css` | 修改 | 聊天界面完整样式（气泡、三栏、回复面板等） |
| `static/js/app.js` | 修改 | 聊天前端逻辑（账号切换、会话管理、消息渲染、SSE 连接、关键词编辑） |

## 技术细节

- **消息存储**：新增 `chat_messages` 表，记录所有收发消息，支持分页加载历史
- **SSE 推送**：使用 `fetch` + `ReadableStream`（非 EventSource），支持 Bearer token 认证
- **消息去重**：发送消息后由 SSE 统一推送显示，避免本地+SSE 双重渲染
- **会话买家名称**：SQL 查询通过 LEFT JOIN 从 direction=2 消息中提取买家昵称

## 兼容性

- 保留原有 `loadImAccountList()`、`onImAccountChange()` 等函数名作为兼容桩
- Docker 部署无需额外配置，重启容器即可生效
- 不影响现有自动回复、订单管理等功能