### PR TITLE
Fix QR login verification cookie shape

### DIFF
--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -1,0 +1,20 @@
+import unittest
+
+from utils.qr_login import QRLoginManager
+
+
+class QRLoginCookieTests(unittest.TestCase):
+    def test_browser_cookies_use_playwright_url_shape(self):
+        manager = QRLoginManager()
+
+        cookies = manager._build_browser_cookies(
+            "https://passport.goofish.com/iv/remote/pc/mini_login_check.htm",
+            {"foo": "bar"},
+        )
+
+        self.assertEqual(cookies[0]["url"], "https://passport.goofish.com")
+        self.assertNotIn("path", cookies[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/qr_login.py
+++ b/utils/qr_login.py
@@ -118,7 +118,6 @@ class QRLoginManager:
                 'name': name,
                 'value': str(value),
                 'url': target_origin,
-                'path': '/',
             })
 
         return browser_cookies


### PR DESCRIPTION
## Summary\n- Fix Playwright cookie conversion for QR login verification pages by using the URL cookie shape without a conflicting path field\n- Add a regression test covering the Playwright cookie payload\n\n## Verification\n- .venv/bin/python -m unittest tests.test_qr_login