### PR TITLE
fix: improve Xianyu login verification flow

### DIFF
--- a/reply_server.py
+++ b/reply_server.py
@@ -5266,6 +5266,13 @@ async def password_login(
             if XianyuLive.is_manual_refresh_active(account_id):
                 return {'success': False, 'message': f'账号 {account_id} 正在执行手动刷新，请稍候再试'}
 
+        allow_headless_password_login = (
+            os.environ.get('XY_PASSWORD_LOGIN_ALLOW_HEADLESS', '').strip().lower()
+            in {'1', 'true', 'yes', 'on'}
+        )
+        if not allow_headless_password_login:
+            show_browser = True
+
         if not account_id or not account or not password:
             return {'success': False, 'message': '账号ID、登录账号和密码不能为空'}
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -13250,7 +13250,7 @@ function showQRCodeError(message) {
     </div>
     `;
     document.getElementById('qrCodeImage').style.display = 'none';
-    document.getElementById('statusText').textContent = '生成失败';
+    document.getElementById('statusText').textContent = '扫码未完成';
     document.getElementById('statusSpinner').style.display = 'none';
 }
 

--- a/utils/qr_login.py
+++ b/utils/qr_login.py
@@ -16,7 +16,7 @@ import qrcode
 import qrcode.constants
 from loguru import logger
 import hashlib
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 from utils.image_utils import image_manager
 
@@ -123,6 +123,20 @@ class QRLoginManager:
 
         return browser_cookies
 
+    def _collect_client_cookie_dict(self, client: httpx.AsyncClient) -> Dict[str, str]:
+        """Collect all cookies from an httpx client regardless of domain."""
+        cookie_dict = {}
+        try:
+            for cookie in client.cookies.jar:
+                if cookie.name and cookie.value is not None:
+                    cookie_dict[str(cookie.name)] = str(cookie.value)
+        except Exception:
+            try:
+                cookie_dict.update({str(k): str(v) for k, v in client.cookies.items()})
+            except Exception:
+                pass
+        return cookie_dict
+
     def _normalize_cookie_dict(self, cookies: Any) -> Dict[str, str]:
         """将不同形式的Cookie数据统一转换为字典"""
         if isinstance(cookies, dict) or hasattr(cookies, 'items'):
@@ -158,7 +172,7 @@ class QRLoginManager:
             return False
 
         companion_keys = ('cookie2', 'havana_lgc2_77', '_tb_token_', 'sgcookie')
-        return any(cookie_dict.get(key) for key in companion_keys)
+        return all(cookie_dict.get(key) for key in companion_keys)
 
     def _is_logged_in_url(self, url: str) -> bool:
         """判断URL是否已经跳转到登录后的页面"""
@@ -520,6 +534,12 @@ class QRLoginManager:
                     # 获取二维码内容
                     qr_content = results["content"]["data"]["codeContent"]
                     session.qr_content = qr_content
+                    generated_login_token = (
+                        results["content"]["data"].get("lgToken")
+                        or parse_qs(urlparse(qr_content).query).get("lgToken", [None])[0]
+                    )
+                    if generated_login_token:
+                        session.params["_generated_login_token"] = generated_login_token
 
                     # 生成二维码图片（base64格式）
                     qr = qrcode.QRCode(
@@ -583,6 +603,60 @@ class QRLoginManager:
             )
             return resp
 
+    async def _complete_qrcode_token_login(self, session: QRLoginSession, login_token: str) -> bool:
+        """二维码确认后用 login token 完整收口登录态，补齐 havana 等会话 Cookie。"""
+        if not login_token:
+            return False
+
+        device_id = session.cookies.get('cna') or session.params.get('deviceId') or ''
+        headers = {
+            **self.headers,
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Referer': f'{self.host}/mini_login.htm',
+            'Origin': self.host,
+        }
+
+        try:
+            async with httpx.AsyncClient(follow_redirects=True, timeout=self.timeout, proxy=self.proxy) as client:
+                client.cookies.update(session.cookies)
+                login_resp = await client.post(
+                    f"{self.host}/login_token/login.do",
+                    params={
+                        'token': login_token,
+                        'subFlow': 'DIALOG_CHECK_LOGIN_RPC',
+                        'nextCode': '0018',
+                        'bizScene': 'qrcode',
+                        'confirm': 'true',
+                    },
+                    data={'deviceId': device_id},
+                    headers=headers,
+                )
+                self._merge_session_cookies(session, login_resp.cookies)
+                self._merge_session_cookies(session, self._collect_client_cookie_dict(client))
+                logger.info(
+                    f"扫码登录token收口完成: status={login_resp.status_code}, "
+                    f"havana={'有' if session.cookies.get('havana_lgc2_77') else '无'}"
+                )
+
+                # 访问一次闲鱼页面，触发登录态 Cookie 在 goofish 域稳定落盘。
+                try:
+                    await client.get(
+                        'https://www.goofish.com/im',
+                        headers={
+                            **self.headers,
+                            'Referer': 'https://www.goofish.com/',
+                            'Origin': 'https://www.goofish.com',
+                        },
+                    )
+                    self._merge_session_cookies(session, self._collect_client_cookie_dict(client))
+                except Exception as warm_e:
+                    logger.warning(f"扫码登录token收口后的页面预热失败，继续使用当前Cookie: {warm_e}")
+
+            return self._has_completed_login_cookies(session.cookies)
+        except Exception as e:
+            logger.error(f"扫码登录token收口失败: {e}")
+            return False
+
     async def _monitor_qr_status(self, session_id: str):
         """监控二维码状态"""
         try:
@@ -642,8 +716,22 @@ class QRLoginManager:
                             await asyncio.sleep(0.8)
                             continue
                         else:
-                            # 登录成功
-                            if self._mark_session_success(session, resp.cookies, 'api'):
+                            self._merge_session_cookies(session, resp.cookies)
+                            qdata = resp.json().get("content", {}).get("data", {}) or {}
+                            login_token = (
+                                qdata.get("token")
+                                or qdata.get("lgToken")
+                                or session.params.get("_generated_login_token")
+                            )
+                            if login_token:
+                                await self._complete_qrcode_token_login(session, login_token)
+                            else:
+                                logger.warning(f"扫码登录API返回成功状态，但没有login token: {session_id}")
+
+                            # 扫码确认后先把已拿到的 Cookie 交给后续真实 Cookie 刷新流程处理。
+                            # 部分账号不会在 qrcode query/login_token 链路里直接返回 havana_lgc2_77，
+                            # 如果这里强制要求全量 Cookie，前端会误报二维码过期/生成失败。
+                            if self._mark_session_success(session, session.cookies, 'api', require_complete_cookies=False):
                                 break
                             logger.warning(f"扫码登录API返回成功状态，但关键Cookie不足: {session_id}")
 

--- a/utils/qr_login_lite.py
+++ b/utils/qr_login_lite.py
@@ -26,7 +26,7 @@ import json
 import sys
 import time
 from typing import Any, Callable, Dict, Optional, Tuple
-from urllib.parse import quote
+from urllib.parse import parse_qs, quote, urlparse
 
 import requests
 from loguru import logger
@@ -198,6 +198,11 @@ def qrcode_login_lite(
     if not (qr_url and qr_t and qr_ck):
         raise RuntimeError(f"生成二维码失败: {gen_resp}")
 
+    generated_login_token = (
+        gen_data.get("lgToken")
+        or parse_qs(urlparse(qr_url).query).get("lgToken", [None])[0]
+    )
+
     logger.info(f"获取到登录二维码: {qr_url}")
     if on_qr_url is not None:
         try:
@@ -232,7 +237,7 @@ def qrcode_login_lite(
     }
 
     deadline = time.time() + timeout
-    login_token: Optional[str] = None
+    login_token: Optional[str] = generated_login_token
     last_status = ""
 
     while time.time() < deadline:
@@ -266,7 +271,7 @@ def qrcode_login_lite(
                     logger.exception("on_status 回调抛异常")
 
         if status == "CONFIRMED":
-            login_token = qdata.get("token") or qdata.get("lgToken")
+            login_token = qdata.get("token") or qdata.get("lgToken") or generated_login_token
             break
         if status == "EXPIRED":
             raise TimeoutError("二维码已过期，请重新调用 qrcode_login_lite()")
@@ -326,9 +331,13 @@ def qrcode_login_lite(
         raise RuntimeError("登录链路完成但未拿到 unb cookie，扫码登录失败")
 
     cookies_dict: Dict[str, str] = {}
+    cookie_domains: Dict[str, str] = {}
     for c in s.cookies:
-        if c.domain and (".goofish.com" in c.domain or ".mmstat.com" in c.domain):
-            cookies_dict[c.name] = c.value
+        cookies_dict[c.name] = c.value
+        cookie_domains[c.name] = c.domain or ""
+    logger.info(f"扫码登录最终Cookie字段: {sorted(cookies_dict.keys())}")
+    if "havana_lgc2_77" in cookies_dict:
+        logger.info(f"扫码登录已获取 havana_lgc2_77，domain={cookie_domains.get('havana_lgc2_77')}")
 
     device_id = generate_device_id(unb)
     account_info: Dict[str, Any] = {

--- a/utils/xianyu_slider_stealth.py
+++ b/utils/xianyu_slider_stealth.py
@@ -20,7 +20,7 @@ import re
 import sys
 import socket
 from datetime import datetime
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, quote_plus, urlencode, urlparse
 from playwright.sync_api import sync_playwright as playwright_sync_playwright, ElementHandle
 try:
     from patchright.sync_api import sync_playwright as patchright_sync_playwright
@@ -1008,6 +1008,15 @@ class XianyuSliderStealth:
         self.keep_verification_screenshots = (
             os.environ.get("XY_KEEP_VERIFICATION_SCREENSHOT", "").strip().lower() in {"1", "true", "yes", "on"}
         )
+        manual_slider_wait_timeout_text = os.environ.get("XY_MANUAL_SLIDER_WAIT_TIMEOUT", "").strip()
+        try:
+            self.manual_slider_wait_timeout = (
+                max(30, int(manual_slider_wait_timeout_text))
+                if manual_slider_wait_timeout_text
+                else 900
+            )
+        except ValueError:
+            self.manual_slider_wait_timeout = 900
         self.disable_headless_warmup = (
             os.environ.get("XY_SLIDER_HEADLESS_WARMUP", "").strip().lower() not in {"1", "true", "yes", "on"}
         )
@@ -3366,6 +3375,88 @@ class XianyuSliderStealth:
         except Exception as e:
             logger.error(f"【{self.pure_user_id}】获取滑块验证成功后的cookie失败: {str(e)}")
             return None
+
+    def _has_visible_slider(self, page=None) -> bool:
+        """Return True when the current page still exposes an Aliyun slider control."""
+        slider_selectors = (
+            '#nc_1_n1z',
+            '.nc-container',
+            '.nc_scale',
+            '.nc-wrapper',
+            '.nc_iconfont',
+            '[class*="nc_"]',
+        )
+        probe_page = page or self.page
+        if not probe_page:
+            return False
+
+        try:
+            frames = [probe_page] + list(getattr(probe_page, 'frames', []) or [])
+        except Exception:
+            frames = [probe_page]
+
+        for frame in frames:
+            for selector in slider_selectors:
+                try:
+                    element = frame.query_selector(selector)
+                    if element and element.is_visible():
+                        return True
+                except Exception:
+                    continue
+        return False
+
+    def _wait_for_manual_slider_completion(self, page=None, reason: str = "slider_failed"):
+        """In headful mode, keep the browser open so the user can solve the slider over VNC."""
+        if self.headless:
+            return None
+        if not self.context or not self.page:
+            return None
+
+        timeout = int(getattr(self, 'manual_slider_wait_timeout', 300) or 300)
+        logger.warning(
+            f"【{self.pure_user_id}】有头模式滑块自动处理失败，保留浏览器窗口 {timeout} 秒等待人工处理 "
+            f"(reason={reason})"
+        )
+        logger.warning(
+            f"【{self.pure_user_id}】请通过 VNC 连接 127.0.0.1:5900，在浏览器中手动完成滑块验证"
+        )
+
+        start_time = time.time()
+        next_progress_log = start_time
+        while time.time() - start_time < timeout:
+            try:
+                monitor_page = self._select_monitor_page(self.context, page or self.page) or page or self.page
+                if not monitor_page:
+                    time.sleep(2)
+                    continue
+
+                if self._has_visible_slider(monitor_page):
+                    now = time.time()
+                    if now >= next_progress_log:
+                        remaining = max(0, int(timeout - (now - start_time)))
+                        logger.info(f"【{self.pure_user_id}】等待人工滑块处理中，剩余 {remaining} 秒")
+                        next_progress_log = now + 30
+                    time.sleep(2)
+                    continue
+
+                try:
+                    monitor_page.wait_for_load_state("networkidle", timeout=5000)
+                except Exception:
+                    pass
+                time.sleep(1)
+
+                cookies = self._get_cookies_after_success()
+                if cookies:
+                    logger.success(
+                        f"【{self.pure_user_id}】人工滑块处理后已获取 cookie，共 {len(cookies)} 个字段"
+                    )
+                    return cookies
+            except Exception as wait_e:
+                logger.warning(f"【{self.pure_user_id}】等待人工滑块处理时出错: {wait_e}")
+                time.sleep(2)
+
+        logger.warning(f"【{self.pure_user_id}】人工滑块等待超时，继续按滑块失败处理")
+        return None
     
     def _save_cookies_to_file(self, cookies):
         """保存cookie到文件"""
@@ -12167,6 +12258,13 @@ class XianyuSliderStealth:
                             f"按 run() 成功收口"
                         )
                         return True, self._post_recovery_cookies
+                    manual_cookies = self._wait_for_manual_slider_completion(
+                        monitor_page,
+                        reason="run_slider_failed",
+                    )
+                    if manual_cookies:
+                        logger.success(f"【{self.pure_user_id}】人工滑块处理成功，按 run() 成功收口")
+                        return True, manual_cookies
                     self._save_debug_snapshot("run_failed", getattr(self, "_detected_slider_frame", None))
                 
                 return success, cookies


### PR DESCRIPTION
## Summary
- default password login to a visible browser unless explicitly allowed to run headless
- complete QR login token handling and collect cookies across domains more reliably
- keep the browser open for manual slider handling over VNC when automated slider solving fails
- avoid showing QR generation failure when the scan flow is simply incomplete

## Root cause
Aliyun slider validation frequently rejects automated or virtualized browser sessions, and the QR flow could mark login as failed before the full cookie set stabilized.

## Validation
- `python -m py_compile reply_server.py utils/qr_login.py utils/qr_login_lite.py utils/xianyu_slider_stealth.py`
- `node --check static/js/app.js`
- verified locally that password login stores cookies and the Xianyu WebSocket reconnects with normal token refresh and heartbeat logs
