### PR TITLE
fix(captcha): sanitize session_id to prevent reflected XSS in control page

### DIFF
--- a/api_captcha_remote.py
+++ b/api_captcha_remote.py
@@ -8,6 +8,8 @@ from fastapi.responses import HTMLResponse, FileResponse
 from pydantic import BaseModel
 from typing import Optional, List
 import asyncio
+import json
+import re
 import os
 from loguru import logger
 
@@ -304,13 +306,18 @@ async def captcha_control_page_with_session(session_id: str):
     """返回带会话ID的滑块控制页面"""
     html_file = "captcha_control.html"
     
+    # Validate session_id to prevent XSS injection
+    if not re.match(r'^[a-zA-Z0-9_-]+$', session_id):
+        raise HTTPException(status_code=400, detail="Invalid session_id")
+    
     if os.path.exists(html_file):
         with open(html_file, 'r', encoding='utf-8') as f:
             html_content = f.read()
-            # 注入会话ID
+            # 注入会话ID (session_id is validated above, use json.dumps for safe JS string)
+            safe_session_id = json.dumps(session_id)
             html_content = html_content.replace(
                 '</body>',
-                f'<script>window.INITIAL_SESSION_ID = "{session_id}";</script></body>'
+                f'<script>window.INITIAL_SESSION_ID = {safe_session_id};</script></body>'
             )
             return HTMLResponse(content=html_content)
     else:


### PR DESCRIPTION
## Vulnerability Summary

**CWE-79 (Reflected XSS)** in `api_captcha_remote.py`, function `captcha_control_page_with_session`.

The endpoint `GET /api/captcha/control/{session_id}` takes a `session_id` path parameter and injects it directly into an HTML response via an f-string:

```python
f'<script>window.INITIAL_SESSION_ID = "{session_id}";</script></body>'
```

Because `session_id` is user-controlled (it comes from the URL path) and is inserted into a `<script>` block without any sanitization or encoding, an attacker can craft a URL that executes arbitrary JavaScript in the victim's browser.

This endpoint has no authentication — the `APIRouter` at line 20 is created without any `dependencies` parameter, so anyone with the URL can trigger the vulnerability.

## Proof of Concept

An attacker sends the victim a link like:

```
https://<target>/api/captcha/control/";alert(document.cookie);//
```

When the victim opens this URL, the server renders:

```html
<script>window.INITIAL_SESSION_ID = "";alert(document.cookie);//";</script>
```

The injected `alert(document.cookie)` executes in the victim's browser context. A real attacker would replace this with cookie exfiltration, session hijacking, or phishing payloads.

You can verify locally by running the FastAPI server and visiting:

```
http://localhost:8000/api/captcha/control/%22;alert(1);//
```

The browser will execute the `alert(1)`.

## Fix Description

The fix applies two layers of defense:

1. **Input validation** — A regex whitelist (`^[a-zA-Z0-9_-]+$`) rejects any `session_id` containing characters outside alphanumerics, hyphens, and underscores. Malicious payloads containing `"`, `<`, `>`, `;`, etc. are rejected with HTTP 400 before reaching the HTML template. Session IDs in this application are machine-generated identifiers, so this validation does not break any legitimate use case.

2. **Output encoding** — Even after validation, the value is passed through `json.dumps()` before interpolation into the `<script>` block. This ensures proper JavaScript string escaping (quotes, backslashes, etc.), providing defense-in-depth in case the validation regex is ever relaxed in the future.

Either layer alone would prevent the XSS, but both together follow the principle of defense in depth.

## What Was Tested

- Verified that a normal alphanumeric `session_id` (e.g., `abc123`) passes validation and renders correctly in the HTML output.
- Verified that a malicious `session_id` (e.g., `";alert(1);//`) is rejected with HTTP 400 before any HTML is generated.
- Verified that `json.dumps()` correctly escapes embedded quotes in the JavaScript string literal.
- Confirmed the fix does not change behavior for any other endpoint in the file.

## Adversarial Review

Before submitting, we considered whether existing protections would prevent exploitation. The endpoint uses `HTMLResponse` directly with string interpolation — FastAPI does not apply any auto-escaping to `HTMLResponse` content. There is no authentication middleware on this router, no CSP headers set by the application, and no input validation on `session_id` prior to this fix. The vulnerability is straightforward to exploit with a single crafted URL requiring only that the victim clicks it.

---

<sub>_Submitted by Sebastion — autonomous open-source security research from [Foundation Machines](https://foundationmachines.ai). Free for public repos via the [Sebastion AI GitHub App](https://github.com/apps/sebastionai)._</sub>
