### PR TITLE
fix: prevent Playwright server process leak in OrderDetailFetcher

### DIFF
--- a/utils/order_detail_fetcher.py
+++ b/utils/order_detail_fetcher.py
@@ -85,6 +85,7 @@ class OrderDetailFetcher:
         self.browser: Optional[Browser] = None
         self.context: Optional[BrowserContext] = None
         self.page: Optional[Page] = None
+        self._playwright = None  # Playwright driver实例，需保存以调用stop()回收进程
         self.headless = headless  # 保存headless设置
         self.cookie_id_for_log = cookie_id_for_log or "unknown"
         self._last_order_status_source = 'unknown'
@@ -123,7 +124,7 @@ class OrderDetailFetcher:
 
             logger.info(f"开始初始化浏览器，headless模式: {headless}")
 
-            playwright = await async_playwright().start()
+            self._playwright = await async_playwright().start()
 
             # 启动浏览器（Docker环境优化）
             browser_args = [
@@ -185,7 +186,7 @@ class OrderDetailFetcher:
                 ])
 
             logger.info(f"启动浏览器，参数: {browser_args}")
-            self.browser = await playwright.chromium.launch(
+            self.browser = await self._playwright.chromium.launch(
                 headless=headless,
                 args=browser_args
             )
@@ -2587,6 +2588,14 @@ class OrderDetailFetcher:
                     pass
                 self.browser = None
 
+            # 必须停止Playwright driver，否则底层server进程和chrome子进程会泄漏
+            if self._playwright:
+                try:
+                    await self._playwright.stop()
+                except:
+                    pass
+                self._playwright = None
+
             self._active_order_id = ''
 
         except Exception as e:
@@ -2603,6 +2612,10 @@ class OrderDetailFetcher:
                 await self.context.close()
             if self.browser:
                 await self.browser.close()
+            # 停止Playwright driver，回收底层server进程
+            if self._playwright:
+                await self._playwright.stop()
+                self._playwright = None
             self._active_order_id = ''
             logger.info("浏览器已关闭")
         except Exception as e:


### PR DESCRIPTION
## 问题

`OrderDetailFetcher.init_browser()` 中，Playwright driver 实例作为局部变量创建，从未保存到 `self`。当 `close()` 或 `_force_close_browser()` 被调用时，只关闭了 browser/context/page，**从未调用 `playwright.stop()`**。

这导致 Playwright server 进程成为孤儿进程，所有 chrome-headless-shell 子进程随之泄漏。

## 实际影响

在生产环境中运行数天后观察到：

- 76 个残留 chrome-headless-shell 进程
- 占用约 3.8 GB 内存
- Swap 几乎用满 (4095.9/4096 MB)
- 系统负载从 1.85 飙升到 4.11

## 修复

将 playwright 实例保存为 `self._playwright`，并在 `close()` 和 `_force_close_browser()` 中调用 `playwright.stop()` 回收底层进程。

### 改动

- `__init__`: 新增 `self._playwright = None`
- `init_browser()`: `playwright = ...` → `self._playwright = ...`
- `close()`: 新增 `self._playwright.stop()`
- `_force_close_browser()`: 新增 `self._playwright.stop()`

共 15 行新增，2 行修改，仅涉及 `utils/order_detail_fetcher.py` 一个文件。