### PR TITLE
docs: 统一 README Star History 区块缩进

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ docker compose up -d
 ## Star History
 
 <a href="https://www.star-history.com/#GuDong2003/xianyu-auto-reply-fix&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=GuDong2003/xianyu-auto-reply-fix&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=GuDong2003/xianyu-auto-reply-fix&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=GuDong2003/xianyu-auto-reply-fix&type=Date" />
- </picture>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=GuDong2003/xianyu-auto-reply-fix&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=GuDong2003/xianyu-auto-reply-fix&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=GuDong2003/xianyu-auto-reply-fix&type=Date" />
+  </picture>
 </a>


### PR DESCRIPTION
将文末 Star History 区块的 HTML 缩进从不规范的 1/3 空格统一为标准的 2 空格层级缩进，仅调整空白，不改变任何内容或渲染效果。