### PR TITLE
fix: 修复浏览器进程泄漏强杀兜底失效、账号任务假死竞态、验证完成后截图误报

### DIFF
--- a/cookie_manager.py
+++ b/cookie_manager.py
@@ -342,8 +342,14 @@ class CookieManager:
     def _start_cookie_task(self, cookie_id: str):
         """启动指定Cookie的任务"""
         if cookie_id in self.tasks:
-            logger.warning(f"Cookie任务已存在，跳过启动: {cookie_id}")
-            return
+            existing_task = self.tasks.get(cookie_id)
+            if existing_task is not None and not existing_task.done():
+                logger.warning(f"Cookie任务已存在，跳过启动: {cookie_id}")
+                return
+            # 任务已结束但引用残留（如任务启动瞬间读到旧的"禁用"状态而立即退出），
+            # 不清理的话该账号任务将永远无法重启
+            logger.warning(f"检测到已结束的残留Cookie任务引用，清理后重新启动: {cookie_id}")
+            self.tasks.pop(cookie_id, None)
 
         cookie_value = self.cookies.get(cookie_id)
         if not cookie_value:

--- a/db_manager.py
+++ b/db_manager.py
@@ -9238,6 +9238,40 @@ Cookie数量: {cookie_count}
             logger.error(f"更新风控日志失败: {e}")
             return False
 
+    def resolve_pending_verification_risk_logs(self, cookie_id: str,
+                                               processing_result: str = '验证已完成',
+                                               result_code: str = 'verification_resolved') -> int:
+        """将指定账号所有悬挂在 processing/pending 状态的验证类风控日志批量置为成功。
+
+        人脸/扫码等验证在检测阶段会写入 processing 状态日志，验证完成后若不回填，
+        前端"查看验证截图"会一直把历史截图当成待处理验证展示。
+
+        Returns:
+            int: 更新的记录数
+        """
+        try:
+            with self.lock:
+                cursor = self.conn.cursor()
+                cursor.execute(
+                    """
+                    UPDATE risk_control_logs
+                    SET processing_status = 'success',
+                        processing_result = ?,
+                        result_code = ?,
+                        error_message = NULL,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE cookie_id = ?
+                      AND event_type IN ('face_verify', 'qr_verify', 'sms_verify', 'unknown')
+                      AND processing_status IN ('processing', 'pending')
+                    """,
+                    (processing_result, result_code, str(cookie_id)),
+                )
+                self.conn.commit()
+                return cursor.rowcount
+        except Exception as e:
+            logger.error(f"批量回填验证风控日志状态失败: {e}")
+            return 0
+
     def get_risk_control_logs(self, cookie_id: str = None, processing_status: str = None,
                               event_type: str = None, trigger_scene: str = None,
                               session_id: str = None, result_code: str = None,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     image: ghcr.io/gudong2003/xianyu-auto-reply-fix:latest
     container_name: xianyu-auto-reply-fix
     restart: unless-stopped
+    # 内置 init 进程回收僵尸进程（chrome 子进程退出后无人 reap 会变 defunct，长期累积）
+    init: true
     # 使用root用户避免权限问题
     user: "0:0"
     # 使用 bash 执行脚本，避免 Windows 行尾格式问题

--- a/reply_server.py
+++ b/reply_server.py
@@ -6532,8 +6532,9 @@ async def get_account_face_verification_screenshot(
                     }
 
         latest_verification_log = _get_latest_verification_risk_log_for_account(account_id)
-        if latest_verification_log and str(latest_verification_log.get('processing_status') or '').strip().lower() == 'failed':
-            if _is_timed_out_verification_risk_log(latest_verification_log):
+        if latest_verification_log:
+            log_status = str(latest_verification_log.get('processing_status') or '').strip().lower()
+            if log_status == 'failed' and _is_timed_out_verification_risk_log(latest_verification_log):
                 timeout_message = (
                     str(latest_verification_log.get('error_message') or '').strip()
                     or '当前验证页面已超时/失效，请重新发起验证'
@@ -6543,7 +6544,14 @@ async def get_account_face_verification_screenshot(
                     'success': False,
                     'message': timeout_message
                 }
-        
+            if log_status == 'success':
+                # 最近一次验证已完成，历史截图仅作留档，不应再当成待处理验证展示
+                log_with_user('info', f"账号 {account_id} 最新验证已完成，无待处理验证", current_user)
+                return {
+                    'success': False,
+                    'message': '最近一次验证已完成，当前没有待处理的验证'
+                }
+
         # 获取该账号的验证截图
         screenshots_dir = os.path.join(static_dir, 'uploads', 'images')
         pattern_jpg = os.path.join(screenshots_dir, f'face_verify_{account_id}_*.jpg')

--- a/utils/xianyu_slider_stealth.py
+++ b/utils/xianyu_slider_stealth.py
@@ -9788,7 +9788,7 @@ class XianyuSliderStealth:
             else:
                 logger.warning(f"【{self.pure_user_id}】{action} {obj_name} 时出错: {e}")
 
-    def _extract_browser_pid(self, runtime_obj) -> Optional[int]:
+    def _extract_browser_pid(self, runtime_obj, playwright_obj=None) -> Optional[int]:
         """尽量从 Playwright runtime 对象上提取浏览器进程 PID。"""
         try:
             process = getattr(runtime_obj, "process", None)
@@ -9803,6 +9803,18 @@ class XianyuSliderStealth:
             pid = getattr(process, "pid", None)
             if pid:
                 return int(pid)
+        except Exception:
+            pass
+        # Python sync API 的 Browser/Context 并不暴露 process 属性，上面两条路径
+        # 实际拿不到 PID（永远返回 None），导致强杀兜底静默失效、浏览器进程常驻泄漏。
+        # 回退为提取 Playwright node driver 的子进程 PID：所有 chrome 进程都挂在
+        # driver 之下，按 driver 进程树清理可以等效覆盖浏览器进程树。
+        try:
+            pw = playwright_obj or getattr(self, "playwright", None)
+            impl = getattr(pw, "_impl_obj", pw)
+            proc = impl._connection._transport._proc
+            if proc is not None and proc.poll() is None:
+                return int(proc.pid)
         except Exception:
             pass
         return None
@@ -9884,6 +9896,17 @@ class XianyuSliderStealth:
         # 先释放槽位，避免后续任一清理步骤卡死把同账号任务永久堵住。
         self._release_concurrency_slot("close_browser开始")
 
+        # 看门狗：优雅清理超过20秒仍未完成（如 close()/stop() 同线程挂死在
+        # 死循环页面上）时，直接按进程树强杀兜底。强杀会让阻塞的 sync 调用
+        # 抛错并被 _safe_pw_dispose 吸收，close_browser 得以继续走完。
+        close_watchdog = threading.Timer(
+            20.0,
+            self._force_kill_browser_process_tree,
+            args=("close_browser_watchdog",),
+        )
+        close_watchdog.daemon = True
+        close_watchdog.start()
+
         # 清理页面 / 上下文 / 浏览器：跨线程 greenlet 错误由 _safe_pw_dispose 统一吸收
         self._safe_pw_dispose('页面', getattr(self, 'page', None), action='close')
         self.page = None
@@ -9920,6 +9943,9 @@ class XianyuSliderStealth:
                 self.temp_dir = None  # 设置为None，防止重复清理
         except Exception as e:
             logger.warning(f"【{self.pure_user_id}】清理临时目录时出错: {e}")
+
+        # 优雅清理按时走完，取消看门狗
+        close_watchdog.cancel()
 
         # 再兜底释放一次，兼容前面提前释放失败的极端情况。
         self._release_concurrency_slot("close_browser收尾")
@@ -11094,7 +11120,7 @@ class XianyuSliderStealth:
 
             if not browser:
                 browser = context.browser
-            self._browser_pid = self._extract_browser_pid(browser or context)
+            self._browser_pid = self._extract_browser_pid(browser or context, playwright)
             page = context.new_page()
             self._apply_headless_network_fingerprint(page, browser_features)
             observed_set_cookie_updates: Dict[str, str] = {}

--- a/utils/xianyu_slider_stealth.py
+++ b/utils/xianyu_slider_stealth.py
@@ -5582,6 +5582,20 @@ class XianyuSliderStealth:
 
         self._log_cookie_snapshot_integrity(cookies_dict, f"{scene}完成后")
         logger.success(f"【{self.pure_user_id}】✅ {scene}后Cookie获取完成，字段数: {len(cookies_dict)}")
+
+        # 验证成功后回填该账号悬挂在 processing 状态的验证类风控日志，
+        # 否则前端"查看验证截图"会一直把历史截图当成待处理验证展示
+        try:
+            from db_manager import db_manager as _db
+            resolved_count = _db.resolve_pending_verification_risk_logs(
+                self.pure_user_id,
+                processing_result=f'{scene}成功，验证已完成',
+            )
+            if resolved_count:
+                logger.info(f"【{self.pure_user_id}】已回填 {resolved_count} 条待处理验证风控日志为成功")
+        except Exception as resolve_err:
+            logger.warning(f"【{self.pure_user_id}】回填验证风控日志状态失败: {resolve_err}")
+
         cleared_pending_markers = []
         sanitized_cookies = dict(cookies_dict)
         for key in self._IDENTITY_VERIFY_PENDING_COOKIE_FIELDS:

--- a/utils/xianyu_slider_stealth.py
+++ b/utils/xianyu_slider_stealth.py
@@ -21,7 +21,7 @@ import sys
 import socket
 import signal
 from datetime import datetime
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, quote_plus, urlencode, urlparse
 from playwright.sync_api import sync_playwright as playwright_sync_playwright, ElementHandle
 try:
     from patchright.sync_api import sync_playwright as patchright_sync_playwright

--- a/utils/xianyu_slider_stealth.py
+++ b/utils/xianyu_slider_stealth.py
@@ -9826,9 +9826,18 @@ class XianyuSliderStealth:
         try:
             pw = playwright_obj or getattr(self, "playwright", None)
             impl = getattr(pw, "_impl_obj", pw)
-            proc = impl._connection._transport._proc
-            if proc is not None and proc.poll() is None:
-                return int(proc.pid)
+            proc = getattr(getattr(getattr(impl, "_connection", None), "_transport", None), "_proc", None)
+            pid = getattr(proc, "pid", None)
+            if proc is not None and pid:
+                # sync API 下 _proc 实际是 asyncio.subprocess.Process：
+                # 只有 returncode 没有 poll()，需要兼容两种存活判断
+                poll = getattr(proc, "poll", None)
+                if callable(poll):
+                    alive = poll() is None
+                else:
+                    alive = getattr(proc, "returncode", None) is None
+                if alive:
+                    return int(pid)
         except Exception:
             pass
         return None
@@ -9921,45 +9930,47 @@ class XianyuSliderStealth:
         close_watchdog.daemon = True
         close_watchdog.start()
 
-        # 清理页面 / 上下文 / 浏览器：跨线程 greenlet 错误由 _safe_pw_dispose 统一吸收
-        self._safe_pw_dispose('页面', getattr(self, 'page', None), action='close')
-        self.page = None
-
-        self._safe_pw_dispose('上下文', getattr(self, 'context', None), action='close')
-        self.context = None
-
-        self._safe_pw_dispose('浏览器', getattr(self, 'browser', None), action='close')
-        self.browser = None
-
-        # 停止 Playwright（_stop_playwright_with_timeout 内部已做跨线程保护）
         try:
-            if hasattr(self, 'playwright') and self.playwright:
-                stopped = self._stop_playwright_with_timeout()
-                if stopped:
-                    logger.info(f"【{self.pure_user_id}】Playwright已停止")
-                else:
-                    logger.warning(f"【{self.pure_user_id}】Playwright未能在当前线程停止，已放弃 stop() 仅置空引用")
-        except Exception as e:
-            logger.warning(f"【{self.pure_user_id}】停止Playwright时出错: {e}")
+            # 清理页面 / 上下文 / 浏览器：跨线程 greenlet 错误由 _safe_pw_dispose 统一吸收
+            self._safe_pw_dispose('页面', getattr(self, 'page', None), action='close')
+            self.page = None
+
+            self._safe_pw_dispose('上下文', getattr(self, 'context', None), action='close')
+            self.context = None
+
+            self._safe_pw_dispose('浏览器', getattr(self, 'browser', None), action='close')
+            self.browser = None
+
+            # 停止 Playwright（_stop_playwright_with_timeout 内部已做跨线程保护）
+            try:
+                if hasattr(self, 'playwright') and self.playwright:
+                    stopped = self._stop_playwright_with_timeout()
+                    if stopped:
+                        logger.info(f"【{self.pure_user_id}】Playwright已停止")
+                    else:
+                        logger.warning(f"【{self.pure_user_id}】Playwright未能在当前线程停止，已放弃 stop() 仅置空引用")
+            except Exception as e:
+                logger.warning(f"【{self.pure_user_id}】停止Playwright时出错: {e}")
+            finally:
+                # 不论 stop 成功与否，都把引用置空，避免下一次 close_browser 又对死引用操作
+                self.playwright = None
+                self._playwright_thread_id = None
+
+            # 再补一层浏览器子进程兜底清理，防止 browser.close()/playwright.stop() 没有真正回收干净
+            self._force_kill_browser_process_tree("close_browser")
+
+            # 清理临时目录
+            try:
+                if hasattr(self, 'temp_dir') and self.temp_dir:
+                    shutil.rmtree(self.temp_dir, ignore_errors=True)
+                    logger.debug(f"【{self.pure_user_id}】临时目录已清理: {self.temp_dir}")
+                    self.temp_dir = None  # 设置为None，防止重复清理
+            except Exception as e:
+                logger.warning(f"【{self.pure_user_id}】清理临时目录时出错: {e}")
         finally:
-            # 不论 stop 成功与否，都把引用置空，避免下一次 close_browser 又对死引用操作
-            self.playwright = None
-            self._playwright_thread_id = None
-
-        # 再补一层浏览器子进程兜底清理，防止 browser.close()/playwright.stop() 没有真正回收干净
-        self._force_kill_browser_process_tree("close_browser")
-
-        # 清理临时目录
-        try:
-            if hasattr(self, 'temp_dir') and self.temp_dir:
-                shutil.rmtree(self.temp_dir, ignore_errors=True)
-                logger.debug(f"【{self.pure_user_id}】临时目录已清理: {self.temp_dir}")
-                self.temp_dir = None  # 设置为None，防止重复清理
-        except Exception as e:
-            logger.warning(f"【{self.pure_user_id}】清理临时目录时出错: {e}")
-
-        # 优雅清理按时走完，取消看门狗
-        close_watchdog.cancel()
+            # 放在 finally：即使清理中途抛出未捕获异常，也保证取消看门狗，
+            # 避免 20 秒后按已过期的 _browser_pid 误杀后续新会话的进程树
+            close_watchdog.cancel()
 
         # 再兜底释放一次，兼容前面提前释放失败的极端情况。
         self._release_concurrency_slot("close_browser收尾")


### PR DESCRIPTION
## 背景

生产环境（Docker 部署）运行 2-3 天后服务卡死：泄漏的 Playwright/Chrome 进程累积（实测 36 个 chrome 进程、3 组 25 小时以上未关闭的会话、15 个僵尸进程），swap 占满、负载冲到 11+，容器健康检查连续超时。排查过程中又发现两个相关联的 bug，一并修复。

## 修复内容（3 个提交）

### 1. 浏览器进程泄漏：强杀兜底静默失效

现有的 `_force_kill_browser_process_tree` 兜底机制实际从未生效过：**Python sync API 的 Browser/Context 对象不暴露 `process` 属性**，`_extract_browser_pid` 的两条提取路径永远返回 `None`，强杀直接空操作返回。可用如下代码验证：

```python
from playwright.sync_api import sync_playwright
p = sync_playwright().start()
b = p.chromium.launch(headless=True)
print(getattr(b, 'process', None))          # None
print(getattr(b.new_context(), 'process', None))  # None
```

修复：
- `_extract_browser_pid` 增加回退路径：从 Playwright driver 的 PipeTransport 子进程句柄（`_impl_obj._connection._transport._proc`）提取 PID。chrome 全部挂在 driver 之下，按 driver 进程树清理等效覆盖浏览器进程树
- `close_browser` 增加 20 秒看门狗：优雅清理挂死（页面死循环时 `close()` 同线程永久阻塞）时强杀进程树解锁流程
- docker-compose 增加 `init: true` 回收僵尸进程（chrome 子进程退出后无人 reap，累积为 defunct）

### 2. 账号任务假死：残留任务引用阻止重启

登录/验证成功后新任务启动与状态置"启用"存在竞态：任务启动瞬间读到旧的"禁用"状态立即退出，但 `self.tasks` 引用不清理；随后置"启用"时被"Cookie任务已存在，跳过启动"拦下，账号永久假死。实测复现日志：

```
15:29:41.392  XianyuLive实例创建成功，开始调用main()...
15:29:41.393  账号已禁用，停止主循环          ← 状态还没置为启用
15:30:00.211  更新Cookie状态: xxx -> 启用
15:30:00.211  Cookie任务已存在，跳过启动: xxx  ← 死任务引用残留
```

修复：`_start_cookie_task` 检查已存在任务的 `done()` 状态，已结束的残留引用先清理再启动。

### 3. 验证完成后前端仍显示待验证截图

- `face_verify` 等风控日志在检测阶段写入 `processing`，验证成功后从不回填（成功只新增一条 `cookie_refresh` 日志），数据库留下永远 processing 的验证记录
- `/face-verification/screenshot` 接口没有处理"验证已成功"的情况，落到 glob 兜底把留档历史截图当成待处理验证返回

修复：新增 `resolve_pending_verification_risk_logs` 批量回填 + 验证成功收尾时调用 + 接口对 success 状态返回"当前没有待处理的验证"。

## 验证情况

以上修复均已在生产环境部署验证：
- 泄漏修复部署后 chrome 进程数稳定，无新增常驻会话
- 假死修复后，扫码登录成功账号任务正常启动并连接
- 截图接口修复后，验证完成的账号返回"没有待处理的验证"提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)