### PR TITLE
fix: 验证截图接口展示过期历史截图（风控/滑块场景）

### DIFF
--- a/reply_server.py
+++ b/reply_server.py
@@ -5257,23 +5257,46 @@ def _get_latest_risk_log_epoch_for_account(account_id: str) -> Optional[float]:
     用于判断历史验证截图是否已过期：只要有比截图更新的风控事件，
     就说明当前的问题不是那次截图对应的验证（如滑块被风控硬拒时不产生新截图），
     此时不应把旧截图当成待处理验证展示。
+
+    注意：风控日志的 created_at/updated_at 由 SQLite CURRENT_TIMESTAMP 写入（UTC），
+    必须用 parse_db_timestamp 按 UTC 解析，否则 Asia/Shanghai 部署会有 8 小时偏差。
     """
-    from datetime import datetime
+    from utils.time_utils import parse_db_timestamp
     logs = db_manager.get_risk_control_logs(cookie_id=str(account_id), limit=5)
     latest = None
     for log in logs:
-        raw = str(log.get('updated_at') or log.get('created_at') or '').strip()
-        if not raw:
+        raw = log.get('updated_at') or log.get('created_at')
+        parsed = parse_db_timestamp(raw)
+        if parsed is None:
             continue
-        for fmt in ('%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M:%S.%f'):
-            try:
-                ts = datetime.strptime(raw, fmt).timestamp()
-                if latest is None or ts > latest:
-                    latest = ts
-                break
-            except ValueError:
-                continue
+        ts = parsed.timestamp()  # parse_db_timestamp 返回 UTC aware datetime，timestamp() 即正确 epoch
+        if latest is None or ts > latest:
+            latest = ts
     return latest
+
+
+# 风控事件晚于截图多少秒即判定截图过期（留 60 秒容差，避免同一验证内的时序抖动误判）
+_SCREENSHOT_STALE_GAP_SECONDS = 60
+
+
+def _evaluate_screenshot_freshness(latest_file: str, latest_risk_epoch: Optional[float]) -> Tuple[str, Optional[str]]:
+    """判断 glob 到的历史截图是否仍应展示。抽成纯函数便于单测。
+
+    Returns (status, message):
+      - ('ok', None)           截图有效，可展示
+      - ('stale', msg)         有更新的风控事件，截图已过期
+      - ('unavailable', msg)   截图 mtime 读取失败（文件被并发删除等），不可用
+    """
+    if latest_risk_epoch is None:
+        return ('ok', None)
+    try:
+        screenshot_mtime = os.path.getmtime(latest_file)
+    except OSError:
+        # 不能默认 0，否则任何近期风控都会把它误判为"过期"；明确报"不可用"
+        return ('unavailable', '验证截图读取失败或已被清理，请重新发起验证')
+    if latest_risk_epoch > screenshot_mtime + _SCREENSHOT_STALE_GAP_SECONDS:
+        return ('stale', '当前没有待处理的验证截图（最近一次风控可能是滑块/Token刷新，已自动处理或需等待风控冷却）')
+    return ('ok', None)
 
 
 def _build_face_verification_screenshot_info(account_id: str, file_path: str) -> Dict[str, Any]:
@@ -6607,21 +6630,13 @@ async def get_account_face_verification_screenshot(
         # 比这张截图还新，说明当前问题不是这张截图对应的验证（如滑块被风控硬拒），
         # 旧截图不应再当成待处理验证展示，避免"当前提醒被历史截图覆盖"的误导
         latest_risk_epoch = _get_latest_risk_log_epoch_for_account(account_id)
-        if latest_risk_epoch is not None:
-            try:
-                screenshot_mtime = os.path.getmtime(latest_file)
-            except OSError:
-                screenshot_mtime = 0
-            if latest_risk_epoch > screenshot_mtime + 60:
-                log_with_user(
-                    'info',
-                    f"账号 {account_id} 最新风控事件晚于历史截图，判定截图已过期，不展示",
-                    current_user,
-                )
-                return {
-                    'success': False,
-                    'message': '当前没有待处理的验证截图（最近一次风控可能是滑块/Token刷新，已自动处理或需等待风控冷却）'
-                }
+        freshness_status, freshness_message = _evaluate_screenshot_freshness(latest_file, latest_risk_epoch)
+        if freshness_status == 'unavailable':
+            log_with_user('warning', f"账号 {account_id} 截图不可用: {freshness_message}", current_user)
+            return {'success': False, 'message': freshness_message}
+        if freshness_status == 'stale':
+            log_with_user('info', f"账号 {account_id} 最新风控事件晚于历史截图，判定截图已过期，不展示", current_user)
+            return {'success': False, 'message': freshness_message}
 
         screenshot_info = _build_face_verification_screenshot_info(account_id, latest_file)
 

--- a/reply_server.py
+++ b/reply_server.py
@@ -5251,6 +5251,31 @@ def _get_latest_verification_risk_log_for_account(account_id: str) -> Optional[D
     return None
 
 
+def _get_latest_risk_log_epoch_for_account(account_id: str) -> Optional[float]:
+    """返回该账号最近一次风控事件（任意类型，含 slider_captcha）的时间戳(epoch秒)。
+
+    用于判断历史验证截图是否已过期：只要有比截图更新的风控事件，
+    就说明当前的问题不是那次截图对应的验证（如滑块被风控硬拒时不产生新截图），
+    此时不应把旧截图当成待处理验证展示。
+    """
+    from datetime import datetime
+    logs = db_manager.get_risk_control_logs(cookie_id=str(account_id), limit=5)
+    latest = None
+    for log in logs:
+        raw = str(log.get('updated_at') or log.get('created_at') or '').strip()
+        if not raw:
+            continue
+        for fmt in ('%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M:%S.%f'):
+            try:
+                ts = datetime.strptime(raw, fmt).timestamp()
+                if latest is None or ts > latest:
+                    latest = ts
+                break
+            except ValueError:
+                continue
+    return latest
+
+
 def _build_face_verification_screenshot_info(account_id: str, file_path: str) -> Dict[str, Any]:
     from datetime import datetime
 
@@ -6577,10 +6602,31 @@ async def get_account_face_verification_screenshot(
         
         # 获取最新的截图
         latest_file = max(screenshot_files, key=os.path.getmtime)
+
+        # 新鲜度门槛：若最近一次风控事件（含 slider_captcha 等不产生截图的类型）
+        # 比这张截图还新，说明当前问题不是这张截图对应的验证（如滑块被风控硬拒），
+        # 旧截图不应再当成待处理验证展示，避免"当前提醒被历史截图覆盖"的误导
+        latest_risk_epoch = _get_latest_risk_log_epoch_for_account(account_id)
+        if latest_risk_epoch is not None:
+            try:
+                screenshot_mtime = os.path.getmtime(latest_file)
+            except OSError:
+                screenshot_mtime = 0
+            if latest_risk_epoch > screenshot_mtime + 60:
+                log_with_user(
+                    'info',
+                    f"账号 {account_id} 最新风控事件晚于历史截图，判定截图已过期，不展示",
+                    current_user,
+                )
+                return {
+                    'success': False,
+                    'message': '当前没有待处理的验证截图（最近一次风控可能是滑块/Token刷新，已自动处理或需等待风控冷却）'
+                }
+
         screenshot_info = _build_face_verification_screenshot_info(account_id, latest_file)
-        
+
         log_with_user('info', f"获取账号 {account_id} 的验证截图", current_user)
-        
+
         return {
             'success': True,
             'screenshot': screenshot_info

--- a/tests/test_verification_screenshot_freshness.py
+++ b/tests/test_verification_screenshot_freshness.py
@@ -1,0 +1,115 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+import reply_server
+from utils.time_utils import parse_db_timestamp
+
+
+class LatestRiskLogEpochUtcTest(unittest.TestCase):
+    """风控日志时间戳必须按 UTC 解析，避免 Asia/Shanghai 部署 8 小时偏差。"""
+
+    def test_utc_string_parsed_without_local_timezone_drift(self):
+        # SQLite CURRENT_TIMESTAMP 写入的是 UTC 无时区字符串
+        utc_str = "2026-07-13 09:52:05"
+        expected = parse_db_timestamp(utc_str).timestamp()
+
+        with mock.patch.object(
+            reply_server.db_manager,
+            "get_risk_control_logs",
+            return_value=[{"updated_at": utc_str}],
+        ):
+            epoch = reply_server._get_latest_risk_log_epoch_for_account("acc")
+
+        self.assertIsNotNone(epoch)
+        self.assertAlmostEqual(epoch, expected, delta=0.001)
+        # 对照"错误地按本地时区解析同一字符串"：东八区下同一时钟串按本地解释得到的
+        # 绝对时刻比按 UTC 解释早 8 小时，故正确(UTC)结果应比它大 28800 秒。
+        naive_local = __import__("datetime").datetime.strptime(
+            utc_str, "%Y-%m-%d %H:%M:%S"
+        ).timestamp()
+        if naive_local != expected:  # 仅当运行环境本地时区非 UTC 时才有区分度
+            self.assertAlmostEqual(expected - naive_local, 8 * 3600, delta=1)
+
+    def test_picks_latest_among_multiple_and_skips_unparseable(self):
+        with mock.patch.object(
+            reply_server.db_manager,
+            "get_risk_control_logs",
+            return_value=[
+                {"updated_at": "2026-07-13 10:00:00"},
+                {"updated_at": ""},                    # 空 -> 跳过
+                {"updated_at": "not-a-date"},          # 非法 -> 跳过
+                {"created_at": "2026-07-13 11:30:00"}, # 回退 created_at
+            ],
+        ):
+            epoch = reply_server._get_latest_risk_log_epoch_for_account("acc")
+        self.assertAlmostEqual(
+            epoch, parse_db_timestamp("2026-07-13 11:30:00").timestamp(), delta=0.001
+        )
+
+    def test_returns_none_when_no_logs(self):
+        with mock.patch.object(
+            reply_server.db_manager, "get_risk_control_logs", return_value=[]
+        ):
+            self.assertIsNone(reply_server._get_latest_risk_log_epoch_for_account("acc"))
+
+
+class ScreenshotFreshnessTest(unittest.TestCase):
+    """截图新鲜度纯函数：60 秒边界 + mtime 读取失败。"""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".jpg", delete=False)
+        self.tmp.write(b"x")
+        self.tmp.close()
+        self.path = self.tmp.name
+        self.mtime = os.path.getmtime(self.path)
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.unlink(self.path)
+
+    def test_no_risk_log_keeps_screenshot(self):
+        self.assertEqual(
+            reply_server._evaluate_screenshot_freshness(self.path, None),
+            ("ok", None),
+        )
+
+    def test_boundary_just_within_gap_is_ok(self):
+        # 风控恰好比截图晚 60 秒：不超过阈值，仍视为有效
+        status, _ = reply_server._evaluate_screenshot_freshness(
+            self.path, self.mtime + reply_server._SCREENSHOT_STALE_GAP_SECONDS
+        )
+        self.assertEqual(status, "ok")
+
+    def test_boundary_just_over_gap_is_stale(self):
+        # 超过 60 秒阈值 1 秒：判定过期
+        status, message = reply_server._evaluate_screenshot_freshness(
+            self.path, self.mtime + reply_server._SCREENSHOT_STALE_GAP_SECONDS + 1
+        )
+        self.assertEqual(status, "stale")
+        self.assertTrue(message)
+
+    def test_older_risk_keeps_screenshot(self):
+        status, _ = reply_server._evaluate_screenshot_freshness(
+            self.path, self.mtime - 3600
+        )
+        self.assertEqual(status, "ok")
+
+    def test_deleted_file_race_reports_unavailable_not_stale(self):
+        # 文件在选中后被并发删除：必须报"不可用"，不能因 mtime=0 误判为"过期"
+        os.unlink(self.path)
+        status, message = reply_server._evaluate_screenshot_freshness(
+            self.path, self.mtime + 10 * 3600  # 即便风控远晚于截图，也不应报 stale
+        )
+        self.assertEqual(status, "unavailable")
+        self.assertTrue(message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

用户收到"Token刷新失败"通知后，点"查看验证截图"看到的却是前一晚的旧截图，当前的问题没有覆盖历史。

## 根因

滑块验证在 token_refresh 场景被风控硬拒（`RGV587_ERROR::SM`）时不产生新截图，而 `/face-verification/screenshot` 接口的验证日志识别（`_get_latest_verification_risk_log_for_account`）只认 `face_verify/qr_verify/sms_verify`，跳过 `slider_captcha`；找不到近期验证日志后回退 `glob` 截图目录，把历史 `face_verify_*.jpg` 旧图当成待处理验证返回。

## 修复

展示 glob 到的最新截图前，取最近一次风控事件（任意类型，含 slider_captcha）的时间戳，若它比截图新 60 秒以上，判定截图已过期，返回"当前没有待处理的验证截图"，不再展示误导性的历史旧图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)